### PR TITLE
feat: add filetype option + assign keys immediately on init

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ use {
 
 ```lua
 require("nvim-paredit").setup({
-  -- should plugin use default keybindings? (default = false)
+  -- should plugin use default keybindings? (default = true)
   use_default_keys = true,
   -- sometimes user wants to restrict plugin to certain file types only
   -- defaults to all supported file types including custom lang

--- a/README.md
+++ b/README.md
@@ -13,10 +13,10 @@
 
 The goal of `nvim-paredit` is to provide a comparable s-expression editing experience in Neovim to that provided by Emacs. This is what is provided:
 
-+ Treesitter based lisp structural editing and cursor motions
-+ Dot-repeatable keybindings
-+ Language extensibility
-+ Programmable API
+- Treesitter based lisp structural editing and cursor motions
+- Dot-repeatable keybindings
+- Language extensibility
+- Programmable API
 
 ## Project Status
 
@@ -29,7 +29,7 @@ You will experience bugs and there are still several unimplemented operations. T
 ### Using [folke/lazy.vim](https://github.com/folke/lazy.nvim)
 
 ```lua
-{ 
+{
   "julienvincent/nvim-paredit",
   config = function()
     require("nvim-paredit").setup()
@@ -52,8 +52,14 @@ use {
 
 ```lua
 require("nvim-paredit").setup({
+  -- should plugin use default keybindings? (default = false)
   use_default_keys = true,
+  -- sometimes user wants to restrict plugin to certain file types only
+  -- defaults to all supported file types including custom lang
+  -- extensions (see next section)
+  filetypes = { "clojure" },
   cursor_behaviour = "auto", -- remain, follow, auto
+  -- list of default keybindings
   keys = {
     [">)"] = { paredit.api.slurp_forwards, "Slurp forwards" },
     [">("] = { paredit.api.slurp_backwards, "Slurp backwards" },
@@ -70,15 +76,24 @@ require("nvim-paredit").setup({
     ["<localleader>o"] = { paredit.api.raise_form, "Raise form" },
     ["<localleader>O"] = { paredit.api.raise_element, "Raise element" },
 
-    ["E"] = { paredit.api.move_to_next_element, "Jump to next element tail", repeatable = false },
-    ["B"] = { paredit.api.move_to_prev_element, "Jump to previous element head", repeatable = false },
+    ["E"] = { 
+      paredit.api.move_to_next_element,
+      "Jump to next element tail",
+      -- by default all keybindings are dot repeatable
+      repeatable = false 
+    },
+    ["B"] = {
+      paredit.api.move_to_prev_element, 
+      "Jump to previous element head",
+      repeatable = false
+    },
   }
 })
 ```
 
 ## Language Support
 
-As this is built using Treesitter it requires that you have the relevant Treesitter grammar installed for your language of choice. Additionally `nvim-paredit` will need explicit support for the treesitter grammar as the node names and metadata of nodes vary between languages. 
+As this is built using Treesitter it requires that you have the relevant Treesitter grammar installed for your language of choice. Additionally `nvim-paredit` will need explicit support for the treesitter grammar as the node names and metadata of nodes vary between languages.
 
 Right now `nvim-paredit` only has built in support for `clojure` but exposes an extension API for adding support for other lisp dialects. Extensions can either be added as config when calling `setup`:
 
@@ -87,7 +102,7 @@ require("nvim-paredit").setup({
   extensions = {
     commonlisp = {
       -- Should return the 'root' of the given Treesitter node. For example:
-      -- The node at cursor in the below example is `()` or 'list_lit': 
+      -- The node at cursor in the below example is `()` or 'list_lit':
       --   '(|)
       -- But the node root is `'()` or 'quoting_lit'
       get_node_root = function(node)
@@ -119,7 +134,7 @@ require("nvim-paredit").setup({
 })
 ```
 
-Or by calling the `add_language_extension` API directly. This would be the recommended approach for extension plugin authors.
+Or by calling the `add_language_extension` API directly before the setup. This would be the recommended approach for extension plugin authors.
 
 ```lua
 require("nvim-paredit.lang").add_language_extension("commonlisp", { ... }).
@@ -134,15 +149,15 @@ local paredit = require("nvim-paredit")
 paredit.api.slurp_forwards()
 ```
 
-+ **`slurp_forwards`**
-+ **`slurp_backwards`**
-+ **`barf_forwards`**
-+ **`barf_backwards`**
-+ **`drag_element_forwards`**
-+ **`drag_element_backwards`**
-+ **`drag_form_forwards`**
-+ **`drag_form_backwards`**
-+ **`raise_element`**
-+ **`raise_form`**
-+ **`move_to_next_element`**
-+ **`move_to_prev_element`**
+- **`slurp_forwards`**
+- **`slurp_backwards`**
+- **`barf_forwards`**
+- **`barf_backwards`**
+- **`drag_element_forwards`**
+- **`drag_element_backwards`**
+- **`drag_form_forwards`**
+- **`drag_form_backwards`**
+- **`raise_element`**
+- **`raise_form`**
+- **`move_to_next_element`**
+- **`move_to_prev_element`**

--- a/lua/nvim-paredit/defaults.lua
+++ b/lua/nvim-paredit/defaults.lua
@@ -23,6 +23,7 @@ M.default_keys = {
 }
 
 M.defaults = {
+  use_default_keys = true,
   cursor_behaviour = "auto", -- remain, follow, auto
   keys = {}
 }

--- a/lua/nvim-paredit/init.lua
+++ b/lua/nvim-paredit/init.lua
@@ -8,31 +8,42 @@ local M = {
   api = require("nvim-paredit.api"),
 }
 
-function M.setup(opts)
-  config.update_config(common.merge(defaults.defaults, opts))
+local function setup_keybingings(filetype)
+  local filetypes = config.config.filetypes
+  local keys = config.config.keys
 
+  if common.included_in_table(filetypes, filetype) then
+    keybindings.setup_keybindings({
+      keys = keys,
+      buf = 0,
+    })
+  end
+end
+
+function M.setup(opts)
   for filetype, api in pairs(opts.extensions or {}) do
     lang.add_language_extension(filetype, api)
   end
 
+  local filetypes = opts.filetypes or lang.filetypes()
+  local keys = opts.keys or {}
+
   if type(opts.use_default_keys) ~= "boolean" or opts.use_default_keys then
-    config.update_config({
-      keys = common.merge(defaults.default_keys, opts.keys or {})
-    })
+    keys = common.merge(defaults.default_keys, opts.keys or {})
   end
+
+  config.update_config({
+    filetypes = filetypes,
+    keys = keys,
+  })
+
+  setup_keybingings(vim.bo.filetype)
 
   vim.api.nvim_create_autocmd("FileType", {
     group = vim.api.nvim_create_augroup("Paredit", { clear = true }),
     pattern = "*",
     callback = function(event)
-      if not common.included_in_table(lang.filetypes(), event.match) then
-        return
-      end
-
-      keybindings.setup_keybindings({
-        keys = config.config.keys or {},
-        buf = event.buf
-      })
+      setup_keybingings(event.match)
     end,
   })
 end

--- a/lua/nvim-paredit/init.lua
+++ b/lua/nvim-paredit/init.lua
@@ -8,14 +8,14 @@ local M = {
   api = require("nvim-paredit.api"),
 }
 
-local function setup_keybingings(filetype)
+local function setup_keybingings(filetype, buf)
   local filetypes = config.config.filetypes
   local keys = config.config.keys
 
   if common.included_in_table(filetypes, filetype) then
     keybindings.setup_keybindings({
       keys = keys,
-      buf = 0,
+      buf = buf,
     })
   end
 end
@@ -29,7 +29,7 @@ function M.setup(opts)
   if type(opts.filetypes) == "table" then
     -- substract langs form opts.filetypes to avoid
     -- binding keymaps to unsupported buffers
-    filetypes = common.remove_extras(opts.filetypes, lang.filetypes())
+    filetypes = common.intersection(opts.filetypes, lang.filetypes())
   else
     filetypes = lang.filetypes()
   end
@@ -51,7 +51,7 @@ function M.setup(opts)
     group = vim.api.nvim_create_augroup("Paredit", { clear = true }),
     pattern = "*",
     callback = function(event)
-      setup_keybingings(event.match)
+      setup_keybingings(event.match, event.buf)
     end,
   })
 end

--- a/lua/nvim-paredit/init.lua
+++ b/lua/nvim-paredit/init.lua
@@ -40,10 +40,10 @@ function M.setup(opts)
     keys = common.merge(defaults.default_keys, opts.keys or {})
   end
 
-  config.update_config({
+  config.update_config(common.merge(opts, {
     filetypes = filetypes,
     keys = keys,
-  })
+  }))
 
   setup_keybingings(vim.bo.filetype)
 

--- a/lua/nvim-paredit/init.lua
+++ b/lua/nvim-paredit/init.lua
@@ -25,7 +25,15 @@ function M.setup(opts)
     lang.add_language_extension(filetype, api)
   end
 
-  local filetypes = opts.filetypes or lang.filetypes()
+  local filetypes
+  if type(opts.filetypes) == "table" then
+    -- substract langs form opts.filetypes to avoid
+    -- binding keymaps to unsupported buffers
+    filetypes = common.remove_extras(opts.filetypes, lang.filetypes())
+  else
+    filetypes = lang.filetypes()
+  end
+
   local keys = opts.keys or {}
 
   if type(opts.use_default_keys) ~= "boolean" or opts.use_default_keys then

--- a/lua/nvim-paredit/utils/common.lua
+++ b/lua/nvim-paredit/utils/common.lua
@@ -39,4 +39,25 @@ function M.compare_positions(a, b)
   return -1
 end
 
+-- Removes all extra keys from t1 which is not in original
+-- and returns a new table
+--
+-- remove_extras({ "a", "b", "f", "d"}, {"a", "b", "c"}) => { "a", "b" }
+function M.remove_extras(tbl, original)
+  local original_set = {}
+  for _, v in ipairs(original) do
+    original_set[v] = true
+  end
+
+  local result = {}
+  for _, v in ipairs(tbl) do
+    if original_set[v] then
+      table.insert(result, v)
+    end
+  end
+
+  return result
+end
+
 return M
+

--- a/lua/nvim-paredit/utils/common.lua
+++ b/lua/nvim-paredit/utils/common.lua
@@ -42,8 +42,8 @@ end
 -- Removes all extra keys from t1 which is not in original
 -- and returns a new table
 --
--- remove_extras({ "a", "b", "f", "d"}, {"a", "b", "c"}) => { "a", "b" }
-function M.remove_extras(tbl, original)
+-- intersection({ "a", "b", "f", "d"}, {"a", "b", "c"}) => { "a", "b" }
+function M.intersection(tbl, original)
   local original_set = {}
   for _, v in ipairs(original) do
     original_set[v] = true

--- a/lua/nvim-paredit/utils/keybindings.lua
+++ b/lua/nvim-paredit/utils/keybindings.lua
@@ -31,7 +31,7 @@ function M.setup_keybindings(opts)
 
     vim.keymap.set({ "n", "x" }, keymap, fn, {
       desc = action[2],
-      buffer = opts.buf,
+      buffer = opts.buf or 0,
       expr = repeatable,
     })
   end


### PR DESCRIPTION
- fix: keybinds wasn't attached to initial buffer because autocommand's callback is not called immediately and user had to reload a file.
- feat: add filetypes option which overrides lang.filetypes(). In some cases user may restrict keybinds attach to certain types only. Also filters out extra unsupported filetypes.