### PR TITLE
Add support for form indentation on slurp/barf

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,27 @@ require("nvim-paredit").setup({
   -- defaults to all supported file types including custom lang
   -- extensions (see next section)
   filetypes = { "clojure" },
+
+  -- This controls where the cursor is placed when performing slurp/barf operations
+  --
+  -- - "remain" - It will never change the cursor position, keeping it in the same place
+  -- - "follow" - It will always place the cursor on the form edge that was moved
+  -- - "auto"   - A combination of remain and follow, it will try keep the cursor in the original position
+  --              unless doing so would result in the cursor no longer being within the original form. In
+  --              this case it will place the cursor on the moved edge
   cursor_behaviour = "auto", -- remain, follow, auto
+
+  indent = {
+    -- This controls how nvim-paredit handles indentation when performing operations which
+    -- should change the indentation of the form (such as when slurping or barfing).
+    --
+    -- When set to true then it will attempt to fix the indentation of nodes operated on.
+    enabled = false,
+    -- A function that will be called after a slurp/barf if you want to provide a custom indentation
+    -- implementation.
+    indentor = require("nvim-paredit.indentation.native").indentor,
+  },
+
   -- list of default keybindings
   keys = {
     [">)"] = { paredit.api.slurp_forwards, "Slurp forwards" },
@@ -111,6 +131,65 @@ require("nvim-paredit").setup({
   }
 })
 ```
+
+## Auto Indentation
+
+Nvim-paredit comes with built-in support for fixing form indentation when performing slurp and barf operations. By default this behaviour is disabled and can be enabled by setting `indent.enabled = true` in the [configuration](#configuration)
+
+The main goal of this implementation is to provide a visual aid to the user, allowing them to confirm they are operating on the correct node and to know when to stop when performing recursive slurp/barf operations. This implementation is fast and does not result in any UI lag or jitter.
+
+The goal is _not_ to be 100% correct. The implementation follows a simple set of rules which account for most scenarios but not all. If a more correct implementation is needed then the native implementation can be replaced by setting the configuration property `intent.indentor`. For example an implementation using `vim.lsp.buf.format` could be built if the user doesn't mind sacrificing performance for correctness.
+
+### Recipes
+
+<details>
+  <summary><code>vim.lsp.buf.format</code></summary>
+
+  Below is a reference implementation for using `vim.lsp.buf.format` to replace the native implementation. This implementation won't be nearly as performant but it will be more correct.
+
+  ```lua
+  local function lsp_indent(event, opts)
+    local traversal = require("nvim-paredit.utils.traversal")
+    local utils = require("nvim-paredit.indentation.utils")
+    local langs = require("nvim-paredit.lang")
+
+    local lang = langs.get_language_api()
+
+    local parent = event.parent
+
+    local child
+    if event.type == "slurp-forwards" then
+      child = parent:named_child(parent:named_child_count() - 1)
+    elseif event.type == "slurp-backwards" then
+      child = parent:named_child(1)
+    elseif event.type == "barf-forwards" then
+      child = traversal.get_next_sibling_ignoring_comments(event.parent, { lang = lang })
+    elseif event.type == "barf-backwards" then
+      child = event.parent
+    else
+      return
+    end
+
+    local child_range = { child:range() }
+    local lines = utils.find_affected_lines(child, utils.get_node_line_range(child_range))
+
+    vim.lsp.buf.format({
+      bufnr = opts.buf or 0,
+      range = {
+        ["start"] = { lines[1] + 1, 0 },
+        ["end"] = { lines[#lines] + 1, 0 },
+      },
+    })
+  end
+
+  require("nvim-paredit").setup({
+    indent = {
+      enabled = true,
+      indentor = lsp_indent
+    }
+  })
+  ```
+</details>
 
 ## Language Support
 
@@ -270,6 +349,7 @@ The main reasons you might want to consider `nvim-paredit` instead are:
 - Easier configuration and an exposed lua API
 - Control over how the cursor is moved during slurp/barf. (For example if you don't want the cursor to always be moved)
 - Recursive slurp/barf operations. If your cursor is in a nested form you can still slurp from the forms parent(s)
+- Automatic form/element indentations on slurp/barf
 - Subjectively better out-of-the-box keybindings
 
 ### [vim-sexp-mappings-for-regular-people](https://github.com/tpope/vim-sexp-mappings-for-regular-people)

--- a/lua/nvim-paredit/config.lua
+++ b/lua/nvim-paredit/config.lua
@@ -1,11 +1,9 @@
-local common = require("nvim-paredit.utils.common")
-
 local M = {}
 
 M.config = {}
 
 function M.update_config(config)
-  M.config = common.merge(M.config, config)
+  M.config = vim.tbl_deep_extend("force", M.config, config)
 end
 
 return M

--- a/lua/nvim-paredit/defaults.lua
+++ b/lua/nvim-paredit/defaults.lua
@@ -61,6 +61,10 @@ M.default_keys = {
 M.defaults = {
   use_default_keys = true,
   cursor_behaviour = "auto", -- remain, follow, auto
+  indent = {
+    enabled = true,
+    indentor = require("nvim-paredit.indentation.native").indentor,
+  },
   keys = {},
 }
 

--- a/lua/nvim-paredit/defaults.lua
+++ b/lua/nvim-paredit/defaults.lua
@@ -62,7 +62,7 @@ M.defaults = {
   use_default_keys = true,
   cursor_behaviour = "auto", -- remain, follow, auto
   indent = {
-    enabled = true,
+    enabled = false,
     indentor = require("nvim-paredit.indentation.native").indentor,
   },
   keys = {},

--- a/lua/nvim-paredit/indentation/init.lua
+++ b/lua/nvim-paredit/indentation/init.lua
@@ -1,0 +1,27 @@
+local config = require("nvim-paredit.config")
+
+local M = {}
+
+function M.handle_indentation(event, opts)
+  local indent = opts.indent or config.config.indent or {}
+  if not indent.enabled or not indent.indentor then
+    return
+  end
+
+  local tree = vim.treesitter.get_parser(0)
+
+  tree:parse()
+  local parent = tree:named_node_for_range(event.parent_range)
+
+  indent.indentor(
+    vim.tbl_deep_extend("force", event, {
+      tree = tree,
+      parent = parent,
+    }),
+    vim.tbl_deep_extend("force", opts, {
+      indent = indent,
+    })
+  )
+end
+
+return M

--- a/lua/nvim-paredit/indentation/native.lua
+++ b/lua/nvim-paredit/indentation/native.lua
@@ -1,0 +1,136 @@
+local traversal = require("nvim-paredit.utils.traversal")
+local utils = require("nvim-paredit.indentation.utils")
+local langs = require("nvim-paredit.lang")
+
+local M = {}
+
+local function dedent_lines(lines, delta, opts)
+  -- stylua: ignore
+  local line_text = vim.api.nvim_buf_get_lines(
+    opts.buf or 0,
+    lines[1], lines[#lines] + 1,
+    false
+  )
+
+  local smallest_distance = delta
+  for _, line in ipairs(line_text) do
+    local first_char_index = string.find(line, "[^%s]")
+    if first_char_index and (first_char_index - 1) < smallest_distance then
+      smallest_distance = first_char_index - 1
+    end
+  end
+
+  for index, line in ipairs(lines) do
+    local deletion_range = smallest_distance
+    local contains_chars = string.find(line_text[index], "[^%s]")
+    if not contains_chars then
+      deletion_range = #line_text[index]
+    end
+    -- stylua: ignore
+    vim.api.nvim_buf_set_text(
+      opts.buf or 0,
+      line, 0,
+      line, deletion_range,
+      {}
+    )
+  end
+end
+
+local function indent_lines(lines, delta, opts)
+  if delta == 0 then
+    return
+  end
+
+  if delta < 0 then
+    return dedent_lines(lines, delta * -1, opts)
+  end
+
+  local chars = string.rep(" ", delta)
+  for _, line in ipairs(lines) do
+    -- stylua: ignore
+    vim.api.nvim_buf_set_text(
+      opts.buf or 0,
+      line, 0,
+      line, 0,
+      {chars}
+    )
+  end
+end
+
+local function indent_barf(event)
+  local lang = langs.get_language_api()
+
+  local lhs
+  local node
+  if event.type == "barf-forwards" then
+    node = traversal.get_next_sibling_ignoring_comments(event.parent, { lang = lang })
+    lhs = event.parent
+  else
+    node = event.parent
+    lhs = traversal.get_prev_sibling_ignoring_comments(event.parent, { lang = lang })
+  end
+
+  if not node or not lhs then
+    return
+  end
+
+  local parent = node:parent()
+
+  local lhs_range = { lhs:range() }
+  local node_range = { node:range() }
+
+  if not utils.node_is_first_on_line(node, { lang = lang }) or lhs_range[1] == node_range[1] then
+    return
+  end
+
+  local lines = utils.find_affected_lines(node, utils.get_node_line_range(node_range))
+
+  local delta
+  if parent:type() == "source" then
+    delta = node_range[2]
+  else
+    local form_edges = lang.get_form_edges(parent)
+    delta = node_range[2] - form_edges.left.range[2] - 1
+  end
+
+  indent_lines(lines, delta * -1, {
+    buf = event.buf,
+  })
+end
+
+local function indent_slurp(event)
+  local parent = event.parent
+  local lang = langs.get_language_api()
+
+  local child
+  if event.type == "slurp-forwards" then
+    child = parent:named_child(parent:named_child_count() - 1)
+  else
+    child = parent:named_child(1)
+  end
+
+  local parent_range = { parent:range() }
+  local child_range = { child:range() }
+
+  if not utils.node_is_first_on_line(child, { lang = lang }) or parent_range[1] == child_range[1] then
+    return
+  end
+
+  local lines = utils.find_affected_lines(child, utils.get_node_line_range(child_range))
+  local form_edges = lang.get_form_edges(parent)
+
+  local delta = form_edges.left.range[4] - child_range[2]
+  indent_lines(lines, delta, {
+    buf = event.buf,
+  })
+end
+
+function M.indentor(event, _)
+  if event.type == "slurp-forwards" or event.type == "slurp-backwards" then
+    indent_slurp(event)
+  else
+    indent_barf(event)
+  end
+end
+
+return M

--- a/lua/nvim-paredit/indentation/native.lua
+++ b/lua/nvim-paredit/indentation/native.lua
@@ -70,14 +70,16 @@ end
 local function indent_barf(event)
   local lang = langs.get_language_api()
 
+  local form = lang.get_node_root(event.parent)
+
   local lhs
   local node
   if event.type == "barf-forwards" then
-    node = traversal.get_next_sibling_ignoring_comments(event.parent, { lang = lang })
-    lhs = event.parent
+    node = traversal.get_next_sibling_ignoring_comments(form, { lang = lang })
+    lhs = form
   else
-    node = event.parent
-    lhs = traversal.get_prev_sibling_ignoring_comments(event.parent, { lang = lang })
+    node = form
+    lhs = traversal.get_prev_sibling_ignoring_comments(form, { lang = lang })
   end
 
   if not node or not lhs then
@@ -118,8 +120,8 @@ local function indent_barf(event)
 end
 
 local function indent_slurp(event)
-  local parent = event.parent
   local lang = langs.get_language_api()
+  local parent = lang.unwrap_form(event.parent)
 
   local child
   if event.type == "slurp-forwards" then

--- a/lua/nvim-paredit/indentation/native.lua
+++ b/lua/nvim-paredit/indentation/native.lua
@@ -99,8 +99,17 @@ local function indent_barf(event)
   if parent:type() == "source" then
     delta = node_range[2]
   else
-    local form_edges = lang.get_form_edges(parent)
-    delta = node_range[2] - form_edges.left.range[2] - 1
+    local row
+    local ref_node = utils.get_first_sibling_on_upper_line(node, { lang = lang })
+    if ref_node then
+      local range = { ref_node:range() }
+      row = range[2]
+    else
+      local form_edges = lang.get_form_edges(parent)
+      row = form_edges.left.range[2] - 1
+    end
+
+    delta = node_range[2] - row
   end
 
   indent_lines(lines, delta * -1, {
@@ -127,9 +136,18 @@ local function indent_slurp(event)
   end
 
   local lines = utils.find_affected_lines(child, utils.get_node_line_range(child_range))
-  local form_edges = lang.get_form_edges(parent)
 
-  local delta = form_edges.left.range[4] - child_range[2]
+  local row
+  local ref_node = utils.get_first_sibling_on_upper_line(child, { lang = lang })
+  if ref_node then
+    local range = { ref_node:range() }
+    row = range[2]
+  else
+    local form_edges = lang.get_form_edges(parent)
+    row = form_edges.left.range[4]
+  end
+
+  local delta = row - child_range[2]
   indent_lines(lines, delta, {
     buf = event.buf,
   })

--- a/lua/nvim-paredit/indentation/utils.lua
+++ b/lua/nvim-paredit/indentation/utils.lua
@@ -61,4 +61,35 @@ function M.node_is_first_on_line(node, opts)
   return sibling_range[3] ~= node_range[1]
 end
 
+-- This functions finds the closest sibling to a given `node` which is:
+-- 1) Not on the same line (one line higher)
+-- 2) Is the first node on the line
+--
+-- This node can be used as an indentation reference point.
+function M.get_first_sibling_on_upper_line(node, opts)
+  local node_range = { node:range() }
+
+  local reference
+  local prev = node
+
+  while prev do
+    prev = traversal.get_prev_sibling_ignoring_comments(prev, opts)
+    if not prev then
+      return reference
+    end
+
+    local sibling_range = { prev:range() }
+
+    if reference and reference:range() ~= sibling_range[1] then
+      return reference
+    end
+
+    if sibling_range[1] ~= node_range[1] then
+      reference = prev
+    end
+  end
+
+  return reference
+end
+
 return M

--- a/lua/nvim-paredit/indentation/utils.lua
+++ b/lua/nvim-paredit/indentation/utils.lua
@@ -1,0 +1,64 @@
+local traversal = require("nvim-paredit.utils.traversal")
+local common = require("nvim-paredit.utils.common")
+
+local M = {}
+
+function M.get_node_line_range(range)
+  local lines = {}
+  for i = range[1], range[3], 1 do
+    table.insert(lines, i)
+  end
+  return lines
+end
+
+function M.get_node_rhs_siblings(node)
+  local nodes = {}
+  local current = node
+  while current do
+    table.insert(nodes, current)
+    current = current:next_named_sibling()
+  end
+  return nodes
+end
+
+function M.find_affected_lines(node, lines)
+  local siblings = M.get_node_rhs_siblings(node)
+  for _, sibling in ipairs(siblings) do
+    local range = { sibling:range() }
+
+    local sibling_is_affected = false
+    for _, line in ipairs(lines) do
+      if line == range[1] then
+        sibling_is_affected = true
+      end
+    end
+
+    if sibling_is_affected then
+      local new_lines = M.get_node_line_range(range)
+      for _, row in ipairs(new_lines) do
+        table.insert(lines, row)
+      end
+    end
+  end
+
+  local parent = node:parent()
+  if parent then
+    return M.find_affected_lines(parent, lines)
+  end
+
+  return common.ordered_set(lines)
+end
+
+function M.node_is_first_on_line(node, opts)
+  local node_range = { node:range() }
+
+  local sibling = traversal.get_prev_sibling_ignoring_comments(node, opts)
+  if not sibling then
+    return true
+  end
+
+  local sibling_range = { sibling:range() }
+  return sibling_range[3] ~= node_range[1]
+end
+
+return M

--- a/lua/nvim-paredit/init.lua
+++ b/lua/nvim-paredit/init.lua
@@ -49,11 +49,11 @@ function M.setup(opts)
   local keys = opts.keys or {}
 
   if type(opts.use_default_keys) ~= "boolean" or opts.use_default_keys then
-    keys = common.merge(defaults.default_keys, opts.keys or {})
+    keys = vim.tbl_deep_extend("force", defaults.default_keys, opts.keys or {})
   end
 
   config.update_config(defaults.defaults)
-  config.update_config(common.merge(opts, {
+  config.update_config(vim.tbl_deep_extend("force", opts, {
     keys = keys,
   }))
 

--- a/lua/nvim-paredit/utils/common.lua
+++ b/lua/nvim-paredit/utils/common.lua
@@ -9,17 +9,6 @@ function M.included_in_table(table, item)
   return false
 end
 
-function M.merge(a, b)
-  local result = {}
-  for k, v in pairs(a) do
-    result[k] = v
-  end
-  for k, v in pairs(b) do
-    result[k] = v
-  end
-  return result
-end
-
 -- Compares the two given { col, row } position tuples and returns -1/0/1 depending
 -- on whether `a` is less than, equal to or greater than `b`
 --
@@ -59,6 +48,20 @@ function M.intersection(tbl, original)
   return result
 end
 
+function M.ordered_set(lines)
+  local seen = {}
+  local result = {}
+  for _, value in ipairs(lines) do
+    if not seen[value] then
+      table.insert(result, value)
+      seen[value] = true
+    end
+  end
+
+  table.sort(result)
+  return result
+end
+
 function M.ensure_visual_mode()
   if vim.api.nvim_get_mode().mode ~= "v" then
     vim.api.nvim_command("normal! v")
@@ -72,11 +75,8 @@ function M.is_whitespace_under_cursor(lang)
   cursor = { cursor[1] - 1, cursor[2] }
 
   local char_under_cursor = vim.api.nvim_buf_get_text(0, cursor[1], cursor[2], cursor[1], cursor[2] + 1, {})
-  return M.included_in_table(
-    lang.whitespace_chars or M.default_whitespace_chars,
-    char_under_cursor[1]
-  ) or char_under_cursor[1] == ""
+  return M.included_in_table(lang.whitespace_chars or M.default_whitespace_chars, char_under_cursor[1])
+    or char_under_cursor[1] == ""
 end
 
 return M
-

--- a/tests/nvim-paredit/indentation_spec.lua
+++ b/tests/nvim-paredit/indentation_spec.lua
@@ -72,6 +72,14 @@ describe("forward slurping indentation", function()
       after_content = { "(", ";; comment", " a)" },
       after_cursor = { 1, 0 },
     },
+
+    {
+      "should indent to the first relevant siblings indentation",
+      before_content = { "(def a []", "  target sibling)", "child" },
+      before_cursor = { 1, 1 },
+      after_content = { "(def a []", "  target sibling", "  child)" },
+      after_cursor = { 1, 1 },
+    },
   })
 end)
 
@@ -148,6 +156,14 @@ describe("forward barfing indentation", function()
       after_content = { "()", ";; comment", "a" },
       after_cursor = { 1, 0 },
     },
+
+    {
+      "should indent to the first relevant siblings indentation",
+      before_content = { "(def a []", "  target (sibling", "          child))" },
+      before_cursor = { 2, 10 },
+      after_content = { "(def a []", "  target (sibling)", "  child)" },
+      after_cursor = { 2, 10 },
+    },
   })
 end)
 
@@ -171,6 +187,14 @@ describe("backward barfing indentation", function()
       before_cursor = { 2, 3 },
       after_content = { "(a", " (bc", " de))" },
       after_cursor = { 2, 3 },
+    },
+
+    {
+      "should indent to the first relevant siblings indentation",
+      before_content = { "(def a []", "  target (sibling", "          child))" },
+      before_cursor = { 3, 1 },
+      after_content = { "(def a []", "  target sibling", "  (child))" },
+      after_cursor = { 3, 2 },
     },
   })
 end)

--- a/tests/nvim-paredit/indentation_spec.lua
+++ b/tests/nvim-paredit/indentation_spec.lua
@@ -1,0 +1,169 @@
+local defaults = require("nvim-paredit.defaults")
+local paredit = require("nvim-paredit.api")
+
+local expect_all = require("tests.nvim-paredit.utils").expect_all
+
+local opts = vim.tbl_deep_extend("force", defaults.defaults, {
+  indent = {
+    enabled = true,
+  },
+})
+
+describe("forward slurping indentation", function()
+  vim.api.nvim_buf_set_option(0, "filetype", "clojure")
+  local function slurp_forwards()
+    paredit.slurp_forwards(opts)
+  end
+
+  expect_all(slurp_forwards, {
+    {
+      "should indent a nested child",
+      before_content = { "()", "a" },
+      before_cursor = { 1, 1 },
+      after_content = { "(", " a)" },
+      after_cursor = { 1, 0 },
+    },
+    {
+      "should indent a multi-line child",
+      before_content = { "()", "(a", " b c)" },
+      before_cursor = { 1, 1 },
+      after_content = { "(", " (a", "  b c))" },
+      after_cursor = { 1, 0 },
+    },
+    {
+      "should indent a multi-line child that pushes other nodes",
+      before_content = { "()", "(a", " b) (c", "d) (e", "f)" },
+      before_cursor = { 1, 1 },
+      after_content = { "(", " (a", "  b)) (c", " d) (e", " f)" },
+      after_cursor = { 1, 0 },
+    },
+    {
+      "should not indent if node is not first on line",
+      before_content = { "(", "a) (a", "b)" },
+      before_cursor = { 1, 1 },
+      after_content = { "(", "a (a", "b))" },
+      after_cursor = { 1, 0 },
+    },
+    {
+      "should not indent when on same line",
+      before_content = "() 1",
+      before_cursor = { 1, 1 },
+      after_content = "( 1)",
+      after_cursor = { 1, 1 },
+    },
+    {
+      "should dedent when node is too far indented",
+      before_content = { "()", "  a" },
+      before_cursor = { 1, 1 },
+      after_content = { "(", " a)" },
+      after_cursor = { 1, 0 },
+    },
+    {
+      "should dedent without deleting characters",
+      before_content = { "()", "   (a", " b)" },
+      before_cursor = { 1, 1 },
+      after_content = { "(", "  (a", "b))" },
+      after_cursor = { 1, 0 },
+    },
+    {
+      "should indent the correct node ignoring comments",
+      before_content = { "()", ";; comment", "a" },
+      before_cursor = { 1, 1 },
+      after_content = { "(", ";; comment", " a)" },
+      after_cursor = { 1, 0 },
+    },
+  })
+end)
+
+describe("backward slurping indentation", function()
+  vim.api.nvim_buf_set_option(0, "filetype", "clojure")
+  local function slurp_backwards()
+    paredit.slurp_backwards(opts)
+  end
+
+  expect_all(slurp_backwards, {
+    {
+      "should indent a nested child",
+      before_content = { "a", "(b)" },
+      before_cursor = { 2, 1 },
+      after_content = { "(a", " b)" },
+      after_cursor = { 2, 2 },
+    },
+    {
+      "should not indent when on same line",
+      before_content = { "a (b)" },
+      before_cursor = { 1, 3 },
+      after_content = { "(a b)" },
+      after_cursor = { 1, 3 },
+    },
+  })
+end)
+
+describe("forward barfing indentation", function()
+  vim.api.nvim_buf_set_option(0, "filetype", "clojure")
+  local function barf_forwards()
+    paredit.barf_forwards(opts)
+  end
+
+  expect_all(barf_forwards, {
+    {
+      "should dedent the barfed child",
+      before_content = { "(", " a)" },
+      before_cursor = { 1, 0 },
+      after_content = { "()", "a" },
+      after_cursor = { 1, 0 },
+    },
+    {
+      "should dedent a multi-line child and affected siblings",
+      before_content = { "(", " (a", "  b c)) (a", " d)" },
+      before_cursor = { 1, 0 },
+      after_content = { "()", "(a", " b c) (a", "d)" },
+      after_cursor = { 1, 0 },
+    },
+    {
+      "should not dedent if node is on the same line",
+      before_content = { "(a", "b c)" },
+      before_cursor = { 1, 1 },
+      after_content = { "(a", "b) c" },
+      after_cursor = { 1, 1 },
+    },
+    {
+      "should not dedent when there is no indentation",
+      before_content = { "(", "a)" },
+      before_cursor = { 1, 0 },
+      after_content = { "()", "a" },
+      after_cursor = { 1, 0 },
+    },
+    {
+      "should dedent the minimum amount without deleting chars",
+      before_content = { "(", "  a) (b", " c)" },
+      before_cursor = { 1, 0 },
+      after_content = { "()", " a (b", "c)" },
+      after_cursor = { 1, 0 },
+    },
+    {
+      "should dedent the correct node ignoring comments",
+      before_content = { "(", ";; comment", " a)" },
+      before_cursor = { 1, 1 },
+      after_content = { "()", ";; comment", "a" },
+      after_cursor = { 1, 0 },
+    },
+  })
+end)
+
+describe("backward barfing indentation", function()
+  vim.api.nvim_buf_set_option(0, "filetype", "clojure")
+  local function barf_backwards()
+    paredit.barf_backwards(opts)
+  end
+
+  expect_all(barf_backwards, {
+    {
+      "should dedent a nested child",
+      before_content = { "(a", " b)" },
+      before_cursor = { 1, 0 },
+      after_content = { "a", "(b)" },
+      after_cursor = { 2, 1 },
+    },
+  })
+end)

--- a/tests/nvim-paredit/indentation_spec.lua
+++ b/tests/nvim-paredit/indentation_spec.lua
@@ -24,6 +24,13 @@ describe("forward slurping indentation", function()
       after_cursor = { 1, 0 },
     },
     {
+      "should indent a nested child from a wrapped parent",
+      before_content = { "@()", "a" },
+      before_cursor = { 1, 2 },
+      after_content = { "@(", "  a)" },
+      after_cursor = { 1, 1 },
+    },
+    {
       "should indent a multi-line child",
       before_content = { "()", "(a", " b c)" },
       before_cursor = { 1, 1 },
@@ -120,6 +127,13 @@ describe("forward barfing indentation", function()
       before_cursor = { 1, 0 },
       after_content = { "()", "a" },
       after_cursor = { 1, 0 },
+    },
+    {
+      "should dedent the barfed child from a wrapped parent",
+      before_content = { "@(", "  a)" },
+      before_cursor = { 1, 1 },
+      after_content = { "@()", "a" },
+      after_cursor = { 1, 1 },
     },
     {
       "should dedent a multi-line child and affected siblings",

--- a/tests/nvim-paredit/indentation_spec.lua
+++ b/tests/nvim-paredit/indentation_spec.lua
@@ -163,7 +163,14 @@ describe("backward barfing indentation", function()
       before_content = { "(a", " b)" },
       before_cursor = { 1, 0 },
       after_content = { "a", "(b)" },
-      after_cursor = { 2, 1 },
+      after_cursor = { 2, 0 },
+    },
+    {
+      "should keep the cursor in the same place",
+      before_content = { "((a", "  bc", "  de))" },
+      before_cursor = { 2, 3 },
+      after_content = { "(a", " (bc", " de))" },
+      after_cursor = { 2, 3 },
     },
   })
 end)


### PR DESCRIPTION
This adds support for automatic indentation correction when slurping and barfing.

The goal of this implementation is to:

1) Provide a visual aid to the user that allows them to confirm they are operating on the correct node, and to know when to stop when performing recursive slurp/barf operations.
2) Be simple to maintain and understand while being as correct as possible
3) Be replaceable with other implementations.
4) Be as performant as possible. There should be no lag or visual jitter

The goal is _not_ to be 100% correct. If a more correct implementation is needed then one can be provided through `indent_fn`. For example, an implementation using `vim.lsp.buf.format` could be built if the user doesn't mind sacrificing performance for correctness.