### PR TITLE
fix #15 motions bug

### DIFF
--- a/lua/nvim-paredit/api/motions.lua
+++ b/lua/nvim-paredit/api/motions.lua
@@ -88,6 +88,9 @@ function M._move_to_element(count, reversed)
     end
   end
 
+  if lang.node_is_comment(current_node) then
+    count = count + 1
+  end
   local next_pos
   if is_in_middle and count == 1 then
     next_pos = node_edge

--- a/tests/nvim-paredit/motion_spec.lua
+++ b/tests/nvim-paredit/motion_spec.lua
@@ -74,6 +74,33 @@ describe("motions", function()
     })
   end)
 
+  it("make an extra motion if cursor is in comment", function()
+    prepare_buffer({
+      content = { "(aa", ";; comment", "bb)" },
+      cursor = { 2, 3 },
+    })
+    paredit.move_to_next_element()
+    expect({
+      cursor = { 3, 1 },
+    })
+    paredit.move_to_prev_element()
+    expect({
+      cursor = { 3, 0 },
+    })
+    paredit.move_to_prev_element()
+    expect({
+      cursor = { 1, 1 },
+    })
+    prepare_buffer({
+      content = { "(aa", ";; comment", "bb)" },
+      cursor = { 2, 3 },
+    })
+    paredit.move_to_prev_element()
+    expect({
+      cursor = { 1, 1 },
+    })
+  end)
+
   it("should move to the end of the current form before jumping to next", function()
     expect_all(paredit.move_to_next_element, {
       {


### PR DESCRIPTION
TIL, comments range takes +1 extra line at the end
```
(+ 1 1)
;; my-comment
(+ 2 2)
```
in this example the comment form's range is {1,0, 2,0}, but not {1,0, 1,13}

This fix utilizes `vcount` feature, if cursor is inside comment just increase `vcount` by 1 to make one extra move