### PR TITLE
Allow passing no opts to setup()

### DIFF
--- a/lua/nvim-paredit/init.lua
+++ b/lua/nvim-paredit/init.lua
@@ -21,6 +21,8 @@ local function setup_keybingings(filetype, buf)
 end
 
 function M.setup(opts)
+  opts = opts or {}
+
   for filetype, api in pairs(opts.extensions or {}) do
     lang.add_language_extension(filetype, api)
   end


### PR DESCRIPTION
As per the installation instructions, passing no parameters to `setup()` should not break