### PR TITLE
Swap default slurp/barf backwards keymaps

### DIFF
--- a/lua/nvim-paredit/defaults.lua
+++ b/lua/nvim-paredit/defaults.lua
@@ -4,10 +4,10 @@ local M = {}
 
 M.default_keys = {
   [">)"] = { api.slurp_forwards, "Slurp forwards" },
-  [">("] = { api.slurp_backwards, "Slurp backwards" },
+  [">("] = { api.barf_backwards, "Barf backwards" },
 
   ["<)"] = { api.barf_forwards, "Barf forwards" },
-  ["<("] = { api.barf_backwards, "Barf backwards" },
+  ["<("] = { api.slurp_backwards, "Slurp backwards" },
 
   [">e"] = { api.drag_element_forwards, "Drag element right" },
   ["<e"] = { api.drag_element_backwards, "Drag element left" },


### PR DESCRIPTION
The default keymaps for slurping and barfing backwards were the wrong way around with respect to the mappings defined by mappings-for-regular-people.

This was a mistake and is better resolved early on while it doesn't affect too many people.

Closes #23