### PR TITLE
Add ae/ie text-selection keymaps for elements

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,18 @@ require("nvim-paredit").setup({
       repeatable = false,
       mode = { "o", "v" }
     },
+    ["ae"] = {
+      api.select_element,
+      "Around element",
+      repeatable = false,
+      mode = { "o", "v" },
+    },
+    ["ie"] = {
+      api.select_element,
+      "Element",
+      repeatable = false,
+      mode = { "o", "v" },
+    },
   }
 })
 ```

--- a/lua/nvim-paredit/api/selections.lua
+++ b/lua/nvim-paredit/api/selections.lua
@@ -99,7 +99,7 @@ function M.select_element()
   M.ensure_visual_mode()
   vim.api.nvim_win_set_cursor(0, { range[1] + 1, range[2] })
   vim.api.nvim_command("normal! o")
-  vim.api.nvim_win_set_cursor(0, { range[3] + 1, range[4] })
+  vim.api.nvim_win_set_cursor(0, { range[3] + 1, range[4] - 1 })
 end
 
 return M

--- a/lua/nvim-paredit/defaults.lua
+++ b/lua/nvim-paredit/defaults.lua
@@ -43,6 +43,19 @@ M.default_keys = {
     repeatable = false,
     mode = { "o", "v" },
   },
+
+  ["ae"] = {
+    api.select_element,
+    "Around element",
+    repeatable = false,
+    mode = { "o", "v" },
+  },
+  ["ie"] = {
+    api.select_element,
+    "Element",
+    repeatable = false,
+    mode = { "o", "v" },
+  },
 }
 
 M.defaults = {

--- a/tests/nvim-paredit/text_object_selections_spec.lua
+++ b/tests/nvim-paredit/text_object_selections_spec.lua
@@ -103,3 +103,44 @@ describe("form selections", function()
     assert.are.same("a a", utils.get_selected_text())
   end)
 end)
+
+describe("element deletions", function()
+  vim.api.nvim_buf_set_option(0, "filetype", "clojure")
+
+  before_each(function()
+    keybindings.setup_keybindings({
+      keys = defaults.default_keys,
+    })
+  end)
+
+  it("should delete the element", function()
+    prepare_buffer({
+      content = "(a :a/b)",
+      cursor = { 1, 5 },
+    })
+    feedkeys("die")
+    expect({
+      content = "(a )",
+      cursor = { 1, 3 },
+    })
+  end)
+end)
+
+describe("element selections", function()
+  vim.api.nvim_buf_set_option(0, "filetype", "clojure")
+
+  before_each(function()
+    keybindings.setup_keybindings({
+      keys = defaults.default_keys,
+    })
+  end)
+
+  it("should select the element", function()
+    prepare_buffer({
+      content = "(a :a/b)",
+      cursor = { 1, 5 },
+    })
+    feedkeys("vie")
+    assert.are.same(":a/b", utils.get_selected_text())
+  end)
+end)


### PR DESCRIPTION
No element-wise keymaps were included in #21. This adds them