### PR TITLE
fix!: wrap functions returns different node depending on cursor position

### DIFF
--- a/lua/nvim-paredit/api/cursor.lua
+++ b/lua/nvim-paredit/api/cursor.lua
@@ -10,7 +10,7 @@ function M.place_cursor(range_or_node, opts)
   if type(range_or_node) == "table" then
     range = range_or_node
   elseif type(range_or_node) == "userdata" then
-    range = range_or_node:range()
+    range = { range_or_node:range() }
   end
 
   if not range then

--- a/lua/nvim-paredit/api/cursor.lua
+++ b/lua/nvim-paredit/api/cursor.lua
@@ -4,21 +4,28 @@ function M.insert_mode()
   vim.api.nvim_feedkeys("i", "n", true)
 end
 
-function M.place_cursor(form, opts)
-  if not form then
+function M.place_cursor(range_or_node, opts)
+  local range
+
+  if type(range_or_node) == "table" then
+    range = range_or_node
+  elseif type(range_or_node) == "userdata" then
+    range = range_or_node:range()
+  end
+
+  if not range then
     return
   end
 
-  local range = { form:range() }
   local cursor_pos
   if opts.placement == "left_edge" then
     cursor_pos = { range[1] + 1, range[2] }
   elseif opts.placement == "inner_start" then
     cursor_pos = { range[1] + 1, range[2] + 1 }
   elseif opts.placement == "inned_end" then
-    cursor_pos = { range[3] + 1, range[4] - 2 }
-  else
     cursor_pos = { range[3] + 1, range[4] - 1 }
+  else
+    cursor_pos = { range[3] + 1, range[4] }
   end
   vim.api.nvim_win_set_cursor(0, cursor_pos)
 

--- a/lua/nvim-paredit/api/cursor.lua
+++ b/lua/nvim-paredit/api/cursor.lua
@@ -4,13 +4,14 @@ function M.insert_mode()
   vim.api.nvim_feedkeys("i", "n", true)
 end
 
-function M.place_cursor(range_or_node, opts)
+function M.get_cursor_pos(range_or_node, opts)
   local range
 
   if type(range_or_node) == "table" then
     range = range_or_node
   elseif type(range_or_node) == "userdata" then
     range = { range_or_node:range() }
+    range[4] = range[4] - 1
   end
 
   if not range then
@@ -22,15 +23,21 @@ function M.place_cursor(range_or_node, opts)
     cursor_pos = { range[1] + 1, range[2] }
   elseif opts.placement == "inner_start" then
     cursor_pos = { range[1] + 1, range[2] + 1 }
-  elseif opts.placement == "inned_end" then
-    cursor_pos = { range[3] + 1, range[4] - 1 }
-  else
+  elseif opts.placement == "inner_end" then
     cursor_pos = { range[3] + 1, range[4] }
+  else
+    cursor_pos = { range[3] + 1, range[4] + 1 }
   end
-  vim.api.nvim_win_set_cursor(0, cursor_pos)
+  return cursor_pos
+end
 
-  if opts.mode == "insert" then
-    M.insert_mode()
+function M.place_cursor(range_or_node, opts)
+  local cursor_pos = M.get_cursor_pos(range_or_node, opts)
+  if cursor_pos then
+    vim.api.nvim_win_set_cursor(0, cursor_pos)
+    if opts.mode == "insert" then
+      M.insert_mode()
+    end
   end
 end
 

--- a/tests/nvim-paredit/cursor_spec.lua
+++ b/tests/nvim-paredit/cursor_spec.lua
@@ -1,0 +1,71 @@
+local paredit = require("nvim-paredit")
+local ts = require("nvim-treesitter.ts_utils")
+local prepare_buffer = require("tests.nvim-paredit.utils").prepare_buffer
+
+describe("cursor pos api tests", function()
+  vim.api.nvim_buf_set_option(0, "filetype", "clojure")
+
+  it("should place cursor inside form at the beginning", function()
+    prepare_buffer({
+      content = { "(a (b))" },
+      cursor = { 1, 0 },
+    })
+
+    local cursor_pos = paredit.cursor.get_cursor_pos({ 0, 0, 0, 6 }, { placement = "inner_start" })
+
+    assert.are.same({ 1, 1 }, cursor_pos)
+
+    local node = ts.get_node_at_cursor()
+    cursor_pos = paredit.cursor.get_cursor_pos(node, { placement = "inner_start" })
+
+    assert.are.same({ 1, 1 }, cursor_pos)
+  end)
+
+  it("should place cursor outside form at the beginning", function()
+    prepare_buffer({
+      content = { "(a (b))" },
+      cursor = { 1, 0 },
+    })
+
+    local cursor_pos = paredit.cursor.get_cursor_pos({ 0, 0, 0, 6 }, { placement = "left_edge" })
+
+    assert.are.same({ 1, 0 }, cursor_pos)
+
+    local node = ts.get_node_at_cursor()
+    cursor_pos = paredit.cursor.get_cursor_pos(node, { placement = "left_edge" })
+
+    assert.are.same({ 1, 0 }, cursor_pos)
+  end)
+
+  it("should place cursor inside form at the end", function()
+    prepare_buffer({
+      content = { "(a ", " (b))" },
+      cursor = { 1, 0 },
+    })
+
+    local cursor_pos = paredit.cursor.get_cursor_pos({ 0, 0, 1, 4 }, { placement = "inner_end" })
+
+    assert.are.same({ 2, 4 }, cursor_pos)
+
+    local node = ts.get_node_at_cursor()
+    cursor_pos = paredit.cursor.get_cursor_pos(node, { placement = "inner_end" })
+
+    assert.are.same({ 2, 4 }, cursor_pos)
+  end)
+
+  it("should place cursor outside form at the end", function()
+    prepare_buffer({
+      content = { "(a ", " (b))" },
+      cursor = { 1, 0 },
+    })
+
+    local cursor_pos = paredit.cursor.get_cursor_pos({ 0, 0, 1, 4 }, { placement = "right_edge" })
+
+    assert.are.same({ 2, 5 }, cursor_pos)
+
+    local node = ts.get_node_at_cursor()
+    cursor_pos = paredit.cursor.get_cursor_pos(node, { placement = "right_edge" })
+
+    assert.are.same({ 2, 5 }, cursor_pos)
+  end)
+end)

--- a/tests/nvim-paredit/form_and_element_wrap_spec.lua
+++ b/tests/nvim-paredit/form_and_element_wrap_spec.lua
@@ -11,7 +11,8 @@ describe("element and form wrap", function()
       cursor = { 1, 4 },
     })
 
-    paredit.wrap.wrap_element_under_cursor("(", ")")
+    local range = paredit.wrap.wrap_element_under_cursor("(", ")")
+    assert.falsy(range)
     expect({
       content = { "(+ 2 :foo/bar)" },
     })
@@ -23,7 +24,8 @@ describe("element and form wrap", function()
       cursor = { 1, 7 },
     })
 
-    paredit.wrap.wrap_element_under_cursor("(", ")")
+    local range = paredit.wrap.wrap_element_under_cursor("(", ")")
+    assert.are.same({ 0, 5, 0, 14 }, range)
     expect({
       content = { "(+ 2 (:foo/bar))" },
     })
@@ -35,7 +37,8 @@ describe("element and form wrap", function()
       cursor = { 1, 0 },
     })
 
-    paredit.wrap.wrap_element_under_cursor("(", ")")
+    local range = paredit.wrap.wrap_element_under_cursor("(", ")")
+    assert.are.same({ 0, 0, 0, 15 }, range)
     expect({
       content = { "((+ 2 :foo/bar))" },
     })
@@ -43,13 +46,14 @@ describe("element and form wrap", function()
 
   it("should wrap namespaced keyword", function()
     prepare_buffer({
-      content = { '(+ 2 "lol")' },
+      content = { "(+ 2 :foo/lol)" },
       cursor = { 1, 7 },
     })
 
-    paredit.wrap.wrap_element_under_cursor("(", ")")
+    local range = paredit.wrap.wrap_element_under_cursor("(", ")")
+    assert.are.same({ 0, 5, 0, 14 }, range)
     expect({
-      content = { '(+ 2 ("lol"))' },
+      content = { "(+ 2 (:foo/lol))" },
     })
   end)
 
@@ -62,7 +66,8 @@ describe("element and form wrap", function()
       cursor = { 2, 4 },
     })
 
-    paredit.wrap.wrap_enclosing_form_under_cursor("(", ")")
+    local range = paredit.wrap.wrap_enclosing_form_under_cursor("(", ")")
+    assert.are.same({ 0, 0, 1, 10 }, range)
     expect({
       content = {
         "((+ 2",
@@ -77,7 +82,8 @@ describe("element and form wrap", function()
       cursor = { 1, 0 },
     })
 
-    paredit.wrap.wrap_enclosing_form_under_cursor("(", ")")
+    local range = paredit.wrap.wrap_enclosing_form_under_cursor("(", ")")
+    assert.are.same({ 0, 0, 0, 15 }, range)
     expect({
       content = { "((+ 2 :foo/bar))" },
     })
@@ -93,7 +99,8 @@ describe("element and form wrap", function()
       cursor = { 2, 4 },
     })
 
-    paredit.wrap.wrap_enclosing_form_under_cursor("(", ")")
+    local range = paredit.wrap.wrap_enclosing_form_under_cursor("(", ")")
+    assert.are.same({ 0, 0, 2, 10 }, range)
     expect({
       content = {
         "((+ 2",


### PR DESCRIPTION
Fixes issue when cursor is not placed correctly in some cases.

Solution: return range instead of node.
- all wrap functions now returns a wrapped range instead of a node (breaking)
- cursor.place_cursor now accepts either range as a table or a TSNode (backwards compatible)

This PR fixes the issue when `ts.get_node_at_cursor` returns different nodes depending on where the cursor is located.

Here are two tests, first one fails (when the cursor at the beginning of a node), but the second test works as expected.
```lua
  it("ts check fails", function()
    prepare_buffer({
      content = { "(a (b))" },
      cursor = { 1, 3 },
    })

    paredit.wrap.wrap_element_under_cursor("( ", ")")

    local parser = vim.treesitter.get_parser(0, vim.bo.filetype)
    parser:parse()
    local node = ts.get_node_at_cursor()
    -- here the returned node is `( (b))` which is not expected
    assert.are.equal("(b)", vim.treesitter.get_node_text(node, 0))
  end)

  it("ts check success", function()
    prepare_buffer({
      content = { "(a (b))" },
      cursor = { 1, 5 },
    })

    paredit.wrap.wrap_element_under_cursor("( ", ")")

    local parser = vim.treesitter.get_parser(0, vim.bo.filetype)
    parser:parse()
    local node = ts.get_node_at_cursor()

    assert.are.equal("(b)", vim.treesitter.get_node_text(node, 0))
  end)
```

