### PR TITLE
Allow setting keymaps to nil to disable

### DIFF
--- a/lua/nvim-paredit/utils/keybindings.lua
+++ b/lua/nvim-paredit/utils/keybindings.lua
@@ -19,6 +19,10 @@ end
 
 function M.setup_keybindings(opts)
   for keymap, action in pairs(opts.keys) do
+    if not action then
+      return
+    end
+
     local repeatable = true
     if type(action.repeatable) == "boolean" then
       repeatable = action.repeatable


### PR DESCRIPTION
This allows disabling specific keymaps. This allows using the defaults but overriding specific keymaps.