### PR TITLE
docs: fix api documentation for wrap form

### DIFF
--- a/README.md
+++ b/README.md
@@ -333,7 +333,7 @@ Cursor api `paredit.cursor`
 
 Require api module:
 ```lua
-local paredit = require("nvim-paredit.api")
+local paredit = require("nvim-paredit")
 ```
 Add following keybindings to config:
 ```lua


### PR DESCRIPTION
I think this part of the readme is old, because only `require("nvim-paredit")` worked for me.