### PR TITLE
fixes #42: Exclusive motion support

### DIFF
--- a/lua/nvim-paredit/api/motions.lua
+++ b/lua/nvim-paredit/api/motions.lua
@@ -140,7 +140,6 @@ function M._move_to_element(count, reversed, is_head, is_exclusive)
     cursor_pos = { next_pos[1] + 1, next_pos[2] - 1 + offset }
   end
 
-  print(is_exclusive, is_head, offset, reversed)
   vim.api.nvim_win_set_cursor(0, cursor_pos)
 end
 

--- a/lua/nvim-paredit/utils/traversal.lua
+++ b/lua/nvim-paredit/utils/traversal.lua
@@ -81,7 +81,7 @@ end
 local function get_sibling_ignoring_comments(node, opts)
   local sibling = opts.sibling_fn(node)
   if not sibling then
-    return opts.sibling or nil
+    return opts.sibling or nil, opts.count + 1
   end
 
   if sibling:extra() or opts.lang.node_is_comment(sibling) then
@@ -94,7 +94,7 @@ local function get_sibling_ignoring_comments(node, opts)
     return get_sibling_ignoring_comments(sibling, new_opts)
   end
 
-  return sibling
+  return sibling, opts.count
 end
 
 function M.get_next_sibling_ignoring_comments(node, opts)

--- a/tests/nvim-paredit/motion_spec.lua
+++ b/tests/nvim-paredit/motion_spec.lua
@@ -55,10 +55,17 @@ describe("motions", function()
     expect({
       cursor = { 1, 15 },
     })
+  end)
+
+  it("should jump to current element's tail if there is no next element", function()
+    prepare_buffer({
+      content = "(aa (bb) @(cc) #{1})",
+      cursor = { 1, 15 },
+    })
 
     paredit.move_to_next_element_head()
     expect({
-      cursor = { 1, 15 },
+      cursor = { 1, 18 },
     })
   end)
 

--- a/tests/nvim-paredit/operator_motion_spec.lua
+++ b/tests/nvim-paredit/operator_motion_spec.lua
@@ -8,7 +8,7 @@ local defaults = require("nvim-paredit.defaults")
 describe("motions with operator pending", function()
   before_each(function()
     keybindings.setup_keybindings({
-      keys = defaults.default_keys
+      keys = defaults.default_keys,
     })
   end)
 
@@ -26,6 +26,42 @@ describe("motions with operator pending", function()
     expect({
       content = "",
       cursor = { 1, 0 },
+    })
+  end)
+
+  it("should delete til next", function()
+    prepare_buffer({
+      content = "(a a) (b b)",
+      cursor = { 1, 0 },
+    })
+    feedkeys("d<S-w>")
+    expect({
+      content = "(b b)",
+      cursor = { 1, 0 },
+    })
+  end)
+
+  it("should delete form if there is no next", function()
+    prepare_buffer({
+      content = "(b b)",
+      cursor = { 1, 0 },
+    })
+    feedkeys("d<S-w>")
+    expect({
+      content = "",
+      cursor = { 1, 0 },
+    })
+  end)
+
+  it("should delete 2 forms within parent form and join up", function()
+    prepare_buffer({
+      content = {"[(a a) (b b) (c c)]"},
+      cursor = { 1, 1 },
+    })
+    feedkeys("2d<S-w>")
+    expect({
+      content = "[(c c)]",
+      cursor = { 1, 1 },
     })
   end)
 
@@ -91,7 +127,7 @@ end)
 describe("motions with operator pending and v:count", function()
   before_each(function()
     keybindings.setup_keybindings({
-      keys = defaults.default_keys
+      keys = defaults.default_keys,
     })
   end)
 


### PR DESCRIPTION
- `move_to_next_element_head` now becomes exclusive when operator mode is active.
- also it acts as `move_to_next_element_tail` when there is no next element available (only in non `reversed` mode), same logic as native `w` motion.