### PR TITLE
Add scheme extension to list

### DIFF
--- a/README.md
+++ b/README.md
@@ -285,6 +285,7 @@ require("nvim-paredit").extension.add_language_extension("commonlisp", { ... }).
 ### Existing Language Extensions
 
 + [fennel](https://github.com/julienvincent/nvim-paredit-fennel)
++ [scheme](https://github.com/ekaitz-zarraga/nvim-paredit-scheme)
 
 ---
 


### PR DESCRIPTION
Using this PR to let you know about my Scheme extension.

I think it mostly works, but I had a hard time making it understand the difference between a standard comment (`;`) and a comment from the srfi 62 (`#;`) that affects the following expression. I'm not sure about how to deal with some other things either but I'll go improving it as I use it in my everyday work (I'm a heavy scheme user).

Thanks for this plugin, it's cool that it's based on treesitter, I was using vim-paredit before, which is based on regular expressions and has a lot of issues with large files. I had a lot of out of sync issues... it was hard to deal with.

This is way better!
I'll let you know about my experience using this.