### PR TITLE
fix: use vim.cmd instead of feedkeys

### DIFF
--- a/lua/nvim-paredit/api/cursor.lua
+++ b/lua/nvim-paredit/api/cursor.lua
@@ -1,7 +1,7 @@
 local M = {}
 
 function M.insert_mode()
-  vim.api.nvim_feedkeys("i", "n", true)
+  vim.cmd("startinsert")
 end
 
 function M.get_cursor_pos(range_or_node, opts)


### PR DESCRIPTION
Current implementation uses `vim.api.nvim_feedkeys` which is slower whan `vim.cmd("startinsert")` due to more general nature (async?) of an API.

Sometimes when user (me 😃) presses `,w`/`,W` (wrap + insert mode) and immediately starts typing the text input gets broken because insert mode is not still activated, `startinsert` is way more faster and solves this issue.