### PR TITLE
Rework test command to be more flexible

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,8 +17,5 @@ jobs:
 
     - uses: extractions/setup-just@v1
 
-    - name: Prepare ${{ matrix.channel }}
-      run: just prepare ${{ matrix.channel }}
-
-    - name: Run Tests
-      run: just test
+    - name: Run tests [${{ matrix.channel }}]
+      run: just test ${{ matrix.channel }}

--- a/Justfile
+++ b/Justfile
@@ -1,36 +1,47 @@
-prepare channel="stable":
+[macos]
+prepare-nvim channel:
   #!/usr/bin/env bash
-  test -d .build/nvim || {
-    mkdir -p ./.build/nvim
+  NVIM_DIR=".build/nvim/{{ channel }}"
 
-    os=$(uname)
-    if [[ "$os" == "Darwin" ]]; then
-      curl -L https://github.com/neovim/neovim/releases/download/{{ channel }}/nvim-macos.tar.gz > ./.build/nvim-macos.tar.gz
-      xattr -c ./.build/nvim-macos.tar.gz
-      tar xzf ./.build/nvim-macos.tar.gz -C ./.build/nvim --strip-components=1
-      rm ./.build/nvim-macos.tar.gz
-    elif [[ "$os" == "Linux" ]]; then
-      curl -L https://github.com/neovim/neovim/releases/download/{{ channel }}/nvim-linux64.tar.gz > ./.build/nvim-linux64.tar.gz
-      tar xzf ./.build/nvim-linux64.tar.gz -C ./.build/nvim --strip-components=1
-      rm ./.build/nvim-linux64.tar.gz
-    else
-      echo "Unsupported operating system: $os"
-      exit 1
-    fi
+  test -d $NVIM_DIR || {
+    mkdir -p $NVIM_DIR
+
+    curl -L https://github.com/neovim/neovim/releases/download/{{ channel }}/nvim-macos.tar.gz > ./.build/nvim-macos.tar.gz
+    xattr -c ./.build/nvim-macos.tar.gz
+    tar xzf ./.build/nvim-macos.tar.gz -C $NVIM_DIR --strip-components=1
+    rm ./.build/nvim-macos.tar.gz
   }
 
+[linux]
+prepare-nvim channel:
+  #!/usr/bin/env bash
+  NVIM_DIR=".build/nvim/{{ channel }}"
+
+  test -d $NVIM_DIR || {
+    mkdir -p $NVIM_DIR
+
+    curl -L https://github.com/neovim/neovim/releases/download/{{ channel }}/nvim-linux64.tar.gz > ./.build/nvim-linux64.tar.gz
+    tar xzf ./.build/nvim-linux64.tar.gz -C $NVIM_DIR --strip-components=1
+    rm ./.build/nvim-linux64.tar.gz
+  }
+
+prepare-dependencies:
+  #!/usr/bin/env bash
   test -d .build/dependencies || {
     mkdir -p ./.build/dependencies
     git clone --depth 1 https://github.com/nvim-lua/plenary.nvim ./.build/dependencies/plenary.nvim
     git clone --depth 1 https://github.com/nvim-treesitter/nvim-treesitter ./.build/dependencies/nvim-treesitter
   }
 
-tests_dir := "tests/nvim-paredit/"
+prepare channel: (prepare-nvim channel) prepare-dependencies
 
-test: prepare
-  ./.build/nvim/bin/nvim --version
-  ./.build/nvim/bin/nvim \
+test channel="stable" file="": (prepare channel)
+  #!/usr/bin/env bash
+  NVIM_DIR=".build/nvim/{{ channel }}"
+
+  ./$NVIM_DIR/bin/nvim --version
+  ./$NVIM_DIR/bin/nvim \
     --headless \
     --noplugin \
     -u tests/init.lua \
-    -c "PlenaryBustedDirectory tests/nvim-paredit { minimal_init='tests/init.lua', sequential=true }"
+    -c "PlenaryBustedDirectory tests/nvim-paredit/{{ file }} { minimal_init='tests/init.lua', sequential=true }"


### PR DESCRIPTION
This reworks the test command to work better when switching between different nvim channels. Currently the .build/nvim dir needs to be deleted manually when switching to a different channel but now different channels are downloaded to separate directories.

Additionally this adds support for specifying an individual file to run the tests for which improves the developer experience of working on tests.