### PR TITLE
Try all parts of a compound filetype

### DIFF
--- a/lua/nvim-paredit/lang/init.lua
+++ b/lua/nvim-paredit/lang/init.lua
@@ -15,7 +15,12 @@ local function keys(tbl)
 end
 
 function M.get_language_api()
-  return langs[vim.bo.filetype]
+  for l in string.gmatch(vim.bo.filetype, "[^.]+") do
+    if langs[l] ~= nil then
+      return langs[l]
+    end
+  end
+  return nil
 end
 
 function M.add_language_extension(filetype, api)


### PR DESCRIPTION
My Neovim setup uses a compound filetype such as `scheme.guile`, which is documented in `:h 'filetype'` as follows:
```
	|FileType| |filetypes|
	When a dot appears in the value then this separates two filetype
	names.  Example:
		/* vim: set filetype=c.doxygen : */
	This will use the "c" filetype first, then the "doxygen" filetype.
	This works both for filetype plugins and for syntax files.  More than
	one dot may appear.
```
This distinction is important, amongst other things, so that [Conjure](https://github.com/Olical/conjure/) select the correct client for the particular dialect of Scheme.  However, currently, `nvim-paredit` chokes on this, even though a valid configuration for `scheme` is available (I am using [nvim-paredit-scheme](http://git.elenq.tech/nvim-paredit-scheme/)), because `get_language_api` cannot find the right entry in `langs`.  A nil value is returned, which trips up the other procedures like this:
```
E5108: Error executing lua ...ck/paqs/start/nvim-paredit/lua/nvim-paredit/api/wrap.lua:15: attempt to index local 'lang' (a nil value)                
stack traceback:
        ...ck/paqs/start/nvim-paredit/lua/nvim-paredit/api/wrap.lua:15: in function 'find_element_under_cursor'
        ...ck/paqs/start/nvim-paredit/lua/nvim-paredit/api/wrap.lua:65: in function 'wrap_element_under_cursor'
        /home/taw/dotfiles/config/nvim/init.lua:190: in function 'fn'
        ...tart/nvim-paredit/lua/nvim-paredit/utils/keybindings.lua:13: in function <...tart/nvim-paredit/lua/nvim-paredit/utils/keybindings.lua:12>
```
This change splits the filetype on `.`, and tries every component until it finds one with a valid configuration.  For me, this fixes the problem and allows the `scheme` configuration to work with `scheme.guile` as the filetype.