### PR TITLE
fix: adds `read_cond_lit` treesitter node

### DIFF
--- a/lua/nvim-paredit/lang/clojure.lua
+++ b/lua/nvim-paredit/lang/clojure.lua
@@ -4,6 +4,7 @@ local common = require("nvim-paredit.utils.common")
 local M = {}
 
 local form_types = {
+  "read_cond_lit",
   "list_lit",
   "vec_lit",
   "map_lit",

--- a/tests/nvim-paredit/barf_spec.lua
+++ b/tests/nvim-paredit/barf_spec.lua
@@ -52,6 +52,13 @@ describe("barfing ::", function()
           after_content = "#{}a",
           after_cursor = { 1, 2 },
         },
+        {
+          "reader conditional",
+          before_content = "#?{:cljs a :clj b}",
+          before_cursor = { 1, 3 },
+          after_content = "#?{:cljs a :clj} b",
+          after_cursor = { 1, 3 },
+        }
       })
     end)
 

--- a/tests/nvim-paredit/barf_spec.lua
+++ b/tests/nvim-paredit/barf_spec.lua
@@ -54,9 +54,9 @@ describe("barfing ::", function()
         },
         {
           "reader conditional",
-          before_content = "#?{:cljs a :clj b}",
+          before_content = "#?(:cljs a :clj b)",
           before_cursor = { 1, 3 },
-          after_content = "#?{:cljs a :clj} b",
+          after_content = "#?(:cljs a :clj) b",
           after_cursor = { 1, 3 },
         }
       })

--- a/tests/nvim-paredit/element_raise_spec.lua
+++ b/tests/nvim-paredit/element_raise_spec.lua
@@ -97,4 +97,17 @@ describe("element raising", function()
       cursor = { 1, 0 },
     })
   end)
+
+  it("should raise a element inside reader conditional", function()
+    prepare_buffer({
+      content = { "#?(:clj (b", " c))" },
+      cursor = { 1, 8 },
+    })
+
+    paredit.raise_element()
+    expect({
+      content = { "(b", " c)" },
+      cursor = { 1, 0 },
+    })
+  end)
 end)

--- a/tests/nvim-paredit/form_raise_spec.lua
+++ b/tests/nvim-paredit/form_raise_spec.lua
@@ -44,6 +44,13 @@ describe("form raising", function()
         after_content = "#(b c)",
         after_cursor = { 1, 0 },
       },
+      {
+        "reader conditional",
+        before_content = "(let [z 1] #?(:clj a :cljs #{b c}))",
+        before_cursor = { 1, 14 },
+        after_content = "#?(:clj a :cljs #{b c})",
+        after_cursor = { 1, 0 },
+      },
     })
   end)
 

--- a/tests/nvim-paredit/form_unwrap_spec.lua
+++ b/tests/nvim-paredit/form_unwrap_spec.lua
@@ -53,4 +53,16 @@ describe("form uwrap (e.g. splice)", function()
       content = { "+ % 2 3" },
     })
   end)
+
+  it("should uwrap reader conditionsl under cursor", function()
+    prepare_buffer({
+      content = { "#?(:clj :foo/bar)" },
+      cursor = { 1, 10 },
+    })
+
+    unwrap.unwrap_form_under_cursor()
+    expect({
+      content = { ":clj :foo/bar" },
+    })
+  end)
 end)

--- a/tests/nvim-paredit/slurp_spec.lua
+++ b/tests/nvim-paredit/slurp_spec.lua
@@ -52,6 +52,13 @@ describe("slurping backward", function()
         after_content = "#{a }",
         after_cursor = { 1, 4 },
       },
+      {
+        "reader conditional",
+        before_content = "a #?(:clj)",
+        before_cursor = { 1, 5 },
+        after_content = "#?(a :clj)",
+        after_cursor = { 1, 5 },
+      }
     })
   end)
 

--- a/tests/nvim-paredit/text_object_selections_spec.lua
+++ b/tests/nvim-paredit/text_object_selections_spec.lua
@@ -51,6 +51,18 @@ describe("form deletions", function()
     })
   end)
 
+  it("should delete the reader conditional form", function()
+    prepare_buffer({
+      content = "#?(:clj a :cljs a)",
+      cursor = { 1, 5 },
+    })
+    feedkeys("daf")
+    expect({
+      content = "",
+      cursor = { 1, 0 },
+    })
+  end)
+
   it("should delete everything in the form", function()
     prepare_buffer({
       content = "(a b)",
@@ -72,6 +84,18 @@ describe("form deletions", function()
     expect({
       content = "()",
       cursor = { 1, 1 },
+    })
+  end)
+
+  it("should delete everything in the reader conditional form", function()
+    prepare_buffer({
+      content = "#?(:clj a b)",
+      cursor = { 1, 4 },
+    })
+    feedkeys("dif")
+    expect({
+      content = "#?()",
+      cursor = { 1, 3 },
     })
   end)
 end)
@@ -149,7 +173,7 @@ describe("top form selections", function()
 
   it("should select the root form and not the siblings", function()
     prepare_buffer({
-      content = {"(+ 1 2)", "(foo (a", "a)) (/ 6 2)"},
+      content = { "(+ 1 2)", "(foo (a", "a)) (/ 6 2)" },
       cursor = { 2, 6 },
     })
     feedkeys("vaF")
@@ -158,7 +182,7 @@ describe("top form selections", function()
 
   it("should select within the form", function()
     prepare_buffer({
-      content = {"(+ 1 2)", "(foo (a", "a)) (/ 6 2)"},
+      content = { "(+ 1 2)", "(foo (a", "a)) (/ 6 2)" },
       cursor = { 2, 6 },
     })
     feedkeys("viF")


### PR DESCRIPTION
Add support for reader conditional forms, e.g.
```clojure
#?(:clj ... 
   :cljs ...)
```