### PR TITLE
Revamp documentation

### DIFF
--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -1,0 +1,309 @@
+## API Documentation
+
+The core API is exposed under the `paredit.api` module
+
+## Index
+
+- **[Slurp / Barf](#slurp--barf)**
+  - [slurp_forwards](#slurp_forwardsopts)
+  - [slurp_backwards](#slurp_backwardsopts)
+  - [barf_forwards](#barf_forwardsopts)
+  - [barf_backwards](#barf_backwardsopts)
+- **[Dragging](#dragging)**
+  - [drag_element_forwards](#drag_element_forwardsopts)
+  - [drag_element_backwards](#drag_element_backwardsopts)
+  - [drag_pair_forwards](#drag_pair_forwards)
+  - [drag_pair_backwards](#drag_pair_backwards)
+  - [drag_form_forwards](#drag_form_forwards)
+  - [drag_form_backwards](#drag_form_backwards)
+- **[Editing](#editing)**
+  - [raise_element](#raise_element)
+  - [raise_form](#raise_form)
+  - [delete_form](#delete_form)
+  - [delete_in_form](#delete_in_form)
+  - [delete_top_level_form](#delete_top_level_form)
+  - [delete_in_top_level_form](#delete_in_top_level_form)
+  - [delete_element](#delete_element)
+- **[Motions](#motions)**
+  - [move_to_next_element_tail](#move_to_next_element_tail)
+  - [move_to_next_element_head](#move_to_next_element_head)
+  - [move_to_prev_element_tail](#move_to_prev_element_tail)
+  - [move_to_prev_element_head](#move_to_prev_element_head)
+  - [move_to_parent_form_start](#move_to_parent_form_start)
+  - [move_to_parent_form_end](#move_to_parent_form_end)
+- **[Selections](#selections)**
+  - [select_around_form](#select_around_form)
+  - [select_in_form](#select_in_form)
+  - [select_around_top_level_form](#select_around_top_level_form)
+  - [select_in_top_level_form](#select_in_top_level_form)
+  - [select_element](#select_element)
+- **[Wrapping](#wrapping)**
+  - [wrap_element_under_cursor](#wrap_element_under_cursorprefix-suffix)
+  - [wrap_enclosing_form_under_cursor](#wrap_enclosing_form_under_cursor)
+  - [unwrap_form_under_cursor](#unwrap_form_under_cursor)
+- **[Cursor Manipulation](#cursor-manipulation)**
+  - [place_cursor](#place_cursorrange_or_node-opts)
+
+---
+
+## **[Slurp / Barf](#slurp--barf)**
+
+##### `SlurpBarfOpts`
+
+```lua
+{
+  cursor_behaviour = "auto", -- remain, follow, auto
+  indent = {
+    enabled = false,
+    indentor = require("nvim-paredit.indentation.native").indentor,
+  },
+}
+```
+
+#### `slurp_forwards([opts])`
+
+Expands the current form by pulling in the next expression into the form.
+
+- **`opts`** - see **[SlurpBarfOpts](#SlurpBarfOpts)**
+
+---
+
+#### `slurp_backwards([opts])`
+
+Expands the current form by pulling the previous expression into the form.
+
+- **`opts`** - see **[SlurpBarfOpts](#SlurpBarfOpts)**
+
+---
+
+#### `barf_forwards([opts])`
+
+Removes the last expression from the current form, pushing it outwards.
+
+- **`opts`** - see **[SlurpBarfOpts](#SlurpBarfOpts)**
+
+---
+
+#### `barf_backwards([opts])`
+
+Removes the first expression from the current form, pushing it outwards.
+
+- **`opts`** - see **[SlurpBarfOpts](#SlurpBarfOpts)**
+
+---
+
+## **[Dragging](#dragging)**
+
+##### `ElementDragOpts`
+
+```lua
+{
+  dragging = {
+    enable_auto_drag = true
+  }
+}
+```
+
+#### `drag_element_forwards([opts])`
+
+Moves the current element or pair forwards within its form.
+
+- **`opts`** - see **[ElementDragOpts](#ElementDragOpts)**
+
+---
+
+#### `drag_element_backwards([opts])`
+
+Moves the current element or pair backwards within its form.
+
+- **`opts`** - see **[ElementDragOpts](#ElementDragOpts)**
+
+---
+
+#### `drag_pair_forwards()`
+
+Moves the current pair of elements forwards within its form.
+
+**Inputs:**
+
+- `pair`: (Optional) The pair of elements to drag forwards. Defaults to the pair at the current cursor position.
+
+---
+
+#### `drag_pair_backwards()`
+
+Moves the current pair of elements backwards within its form.
+
+**Inputs:**
+
+- `pair`: (Optional) The pair of elements to drag backwards. Defaults to the pair at the current cursor position.
+
+---
+
+#### `drag_form_forwards()`
+
+Moves the current form forwards within its parent form.
+
+---
+
+#### `drag_form_backwards()`
+
+Moves the current form backwards within its parent form.
+
+---
+
+## **[Editing](#editing)**
+
+#### `raise_element()`
+
+Raises the current element, removing it from its enclosing form.
+
+---
+
+#### `raise_form()`
+
+Raises the current form, removing it from its enclosing form.
+
+---
+
+#### `delete_form()`
+
+Deletes the current form.
+
+---
+
+#### `delete_in_form()`
+
+Deletes the content inside the current form without removing the form itself.
+
+---
+
+#### `delete_top_level_form()`
+
+Deletes the current top-level form.
+
+---
+
+#### `delete_in_top_level_form()`
+
+Deletes the content inside the current top-level form without removing the form itself.
+
+---
+
+#### `delete_element()`
+
+Deletes the current element.
+
+---
+
+### **[Motions](#motions)**
+
+#### `move_to_next_element_tail()`
+
+Moves the cursor to the tail of the next element in the form.
+
+---
+
+#### `move_to_next_element_head()`
+
+Moves the cursor to the head of the next element in the form.
+
+---
+
+#### `move_to_prev_element_head()`
+
+Moves the cursor to the head of the previous element in the form.
+
+---
+
+#### `move_to_prev_element_tail()`
+
+Moves the cursor to the tail of the previous element in the form.
+
+---
+
+#### `move_to_parent_form_start()`
+
+Moves the cursor to the start of the parent form.
+
+---
+
+#### `move_to_parent_form_end()`
+
+Moves the cursor to the end of the parent form.
+
+---
+
+### **[Selections](#selections)**
+
+#### `select_around_form()`
+
+Selects the form surrounding the cursor, including the enclosing delimiters.
+
+---
+
+#### `select_in_form()`
+
+Selects the content inside the form surrounding the cursor, excluding the enclosing delimiters.
+
+---
+
+#### `select_around_top_level_form()`
+
+Selects the top-level form surrounding the cursor, including the enclosing delimiters.
+
+---
+
+#### `select_in_top_level_form()`
+
+Selects the content inside the top-level form surrounding the cursor, excluding the enclosing delimiters.
+
+---
+
+#### `select_element()`
+
+Selects the current element under the cursor.
+
+---
+
+### **[Wrapping](#wrapping)**
+
+#### `wrap_element_under_cursor(prefix, suffix)`
+
+Wraps the element under the cursor with a prefix and suffix.
+
+- `prefix`: string
+- `suffix`: string
+
+Returns The wrapped `TSNode`.
+
+---
+
+#### `wrap_enclosing_form_under_cursor()`
+
+Wraps the enclosing form under the cursor with a prefix and suffix.
+
+- `prefix`: string
+- `suffix`: string
+
+Returns The wrapped `TSNode`.
+
+#### `unwrap_form_under_cursor()`
+
+Unwraps the nearest form under the cursor. This is called splice in other paredit implementations.
+
+---
+
+### **[Cursor Manipulation](#cursor-manipulation)**
+
+These APIs are exposed from `paredit.api.cursor`.
+
+#### `place_cursor(range_or_node, opts)`
+
+Places the cursor at a specific position within a `TSNode`.
+
+- `node`: The `TSNode` to operate within
+- `opts` table
+  - `placement`: (Optional) The position relative to the node. Can be `left_edge`, `inner_start`, `inner_end`, or
+    `right_edge`. Defaults to `left_edge`.
+  - `mode`: (Optional) The mode for cursor placement. Currently only `insert` is supported, defaults to `normal`.

--- a/docs/language-extension-spec.md
+++ b/docs/language-extension-spec.md
@@ -1,0 +1,55 @@
+# Language Extension Spec
+
+> [!WARNING]
+>
+> This API is considered **very alpha** and may change without warning
+
+### API
+
+```lua
+local language_extension = {
+  -- Should return the 'root' of the given Treesitter node. For example:
+  -- The node at cursor in the below example is `()` or 'list_lit':
+  --   '(|)
+  -- But the node root is `'()` or 'quoting_lit'
+  get_node_root = function(node) end,
+  -- This is the inverse of `get_node_root` for forms and should find the inner node for which
+  -- the forms elements are direct children.
+  --
+  -- For example given the node `'()` or 'quoting_lit', this function should return `()` or 'list_lit'.
+  unwrap_form = function(node) end,
+  -- Accepts a Treesitter node and should return true or false depending on whether the given node
+  -- can be considered a 'form'
+  node_is_form = function(node) end,
+  -- Accepts a Treesitter node and should return true or false depending on whether the given node
+  -- can be considered a 'comment'
+  node_is_comment = function(node) end,
+  -- Accepts a Treesitter node representing a form and should return the 'edges' of the node. This
+  -- includes the node text and the range covered by the node
+  get_form_edges = function(node)
+    return {
+      left = { text = "#{", range = { 0, 0, 0, 2 } },
+      right = { text = "}", range = { 0, 5, 0, 6 } },
+    }
+  end,
+}
+```
+
+See also [the clojure implementation](../lua/nvim-paredit/lang/clojure.lua) for a good reference.
+
+## Registration
+
+Extensions can either be registered as config when calling `setup` or by calling the `add_language_extension` API before
+the setup. The latter would be the recommended approach for extension plugin authors.
+
+```lua
+require("nvim-paredit").setup({
+  extensions = {
+    commonlisp = { ... },
+  },
+})
+```
+
+```lua
+require("nvim-paredit").extension.add_language_extension("commonlisp", { ... }).
+```

--- a/docs/recipes.md
+++ b/docs/recipes.md
@@ -1,0 +1,121 @@
+# Recipes
+
+### Lsp Indentation
+
+Below is a reference implementation for using `vim.lsp.buf.format` to replace the native indent implementation. This
+implementation won't be nearly as performant, but it will be more correct.
+
+```lua
+local function lsp_indent(event, opts)
+  local traversal = require("nvim-paredit.utils.traversal")
+  local utils = require("nvim-paredit.indentation.utils")
+  local langs = require("nvim-paredit.lang")
+
+  local lang = langs.get_language_api()
+
+  local parent = event.parent
+
+  local child
+  if event.type == "slurp-forwards" then
+    child = parent:named_child(parent:named_child_count() - 1)
+  elseif event.type == "slurp-backwards" then
+    child = parent:named_child(1)
+  elseif event.type == "barf-forwards" then
+    child = traversal.get_next_sibling_ignoring_comments(event.parent, { lang = lang })
+  elseif event.type == "barf-backwards" then
+    child = event.parent
+  else
+    return
+  end
+
+  local child_range = { child:range() }
+  local lines = utils.find_affected_lines(child, utils.get_node_line_range(child_range))
+
+  vim.lsp.buf.format({
+    bufnr = opts.buf or 0,
+    range = {
+      ["start"] = { lines[1] + 1, 0 },
+      ["end"] = { lines[#lines] + 1, 0 },
+    },
+  })
+end
+
+local child_range = { child:range() }
+local lines = utils.find_affected_lines(child, utils.get_node_line_range(child_range))
+
+vim.lsp.buf.format({
+  bufnr = opts.buf or 0,
+  range = {
+    ["start"] = { lines[1] + 1, 0 },
+    ["end"] = { lines[#lines] + 1, 0 },
+  },
+})
+end
+
+require("nvim-paredit").setup({
+  indent = {
+    enabled = true,
+    indentor = lsp_indent,
+  },
+})
+```
+
+### Wrap form (head/tail)
+
+This is to mimic the behaviour from `vim-sexp`
+
+Require api module:
+
+```lua
+local paredit = require("nvim-paredit")
+```
+
+Add following keybindings to config:
+
+```lua
+["<localleader>w"] = {
+  function()
+    -- place cursor and set mode to `insert`
+    paredit.cursor.place_cursor(
+      -- wrap element under cursor with `( ` and `)`
+      paredit.wrap.wrap_element_under_cursor("( ", ")"),
+      -- cursor placement opts
+      { placement = "inner_start", mode = "insert" }
+    )
+  end,
+  "Wrap element insert head",
+},
+
+["<localleader>W"] = {
+  function()
+    paredit.cursor.place_cursor(
+      paredit.wrap.wrap_element_under_cursor("(", ")"),
+      { placement = "inner_end", mode = "insert" }
+    )
+  end,
+  "Wrap element insert tail",
+},
+
+-- same as above but for enclosing form
+["<localleader>i"] = {
+  function()
+    paredit.cursor.place_cursor(
+      paredit.wrap.wrap_enclosing_form_under_cursor("( ", ")"),
+      { placement = "inner_start", mode = "insert" }
+    )
+  end,
+  "Wrap form insert head",
+},
+
+["<localleader>I"] = {
+  function()
+    paredit.cursor.place_cursor(
+      paredit.wrap.wrap_enclosing_form_under_cursor("(", ")"),
+      { placement = "inner_end", mode = "insert" }
+    )
+  end,
+  "Wrap form insert tail",
+}
+```
+
+Same approach can be used for other `vim-sexp` keybindings (e.g. `<localleader>e[`) with cursor placement or without.

--- a/lua/nvim-paredit/api/init.lua
+++ b/lua/nvim-paredit/api/init.lua
@@ -6,6 +6,8 @@ local motions = require("nvim-paredit.api.motions")
 local selections = require("nvim-paredit.api.selections")
 local deletions = require("nvim-paredit.api.deletions")
 local common = require("nvim-paredit.utils.common")
+local wrap = require("nvim-paredit.api.wrap")
+local unwrap = require("nvim-paredit.api.unwrap")
 
 local M = {
   slurp_forwards = slurping.slurp_forwards,
@@ -49,6 +51,10 @@ local M = {
   delete_top_level_form = deletions.delete_top_level_form,
   delete_in_top_level_form = deletions.delete_in_top_level_form,
   delete_element = deletions.delete_element,
+
+  wrap_element_under_cursor = wrap.wrap_element_under_cursor,
+  wrap_enclosing_form_under_cursor = wrap.wrap_enclosing_form_under_cursor,
+  unwrap_form_under_cursor = unwrap.unwrap_form_under_cursor,
 }
 
 return M

--- a/lua/nvim-paredit/api/init.lua
+++ b/lua/nvim-paredit/api/init.lua
@@ -5,9 +5,16 @@ local raising = require("nvim-paredit.api.raising")
 local motions = require("nvim-paredit.api.motions")
 local selections = require("nvim-paredit.api.selections")
 local deletions = require("nvim-paredit.api.deletions")
-local common = require("nvim-paredit.utils.common")
 local wrap = require("nvim-paredit.api.wrap")
 local unwrap = require("nvim-paredit.api.unwrap")
+
+-- Use this to wrap an API with if it becomes deprecated
+-- local function deprecate(fn, message)
+--   return function(...)
+--     print("Warning: Deprecated function called. " .. message)
+--     return fn(...)
+--   end
+-- end
 
 local M = {
   slurp_forwards = slurping.slurp_forwards,
@@ -27,13 +34,9 @@ local M = {
   raise_form = raising.raise_form,
   raise_element = raising.raise_element,
 
-  -- TODO: remove deprecated code in next versions
-  move_to_next_element = common.deprecate(motions.move_to_next_element_tail, "use `api.move_to_next_element_tail`"),
   move_to_next_element_tail = motions.move_to_next_element_tail,
   move_to_next_element_head = motions.move_to_next_element_head,
 
-  -- TODO: remove deprecated code in next versions
-  move_to_prev_element = common.deprecate(motions.move_to_prev_element_head, "use `api.move_to_prev_element_head`"),
   move_to_prev_element_head = motions.move_to_prev_element_head,
   move_to_prev_element_tail = motions.move_to_prev_element_tail,
 

--- a/lua/nvim-paredit/api/wrap.lua
+++ b/lua/nvim-paredit/api/wrap.lua
@@ -5,11 +5,6 @@ local langs = require("nvim-paredit.lang")
 
 local M = {}
 
-local function reparse(buf)
-  local parser = vim.treesitter.get_parser(buf, vim.bo.filetype)
-  parser:parse()
-end
-
 function M.find_element_under_cursor(lang)
   local node = ts.get_node_at_cursor()
   return lang.get_node_root(node)

--- a/lua/nvim-paredit/defaults.lua
+++ b/lua/nvim-paredit/defaults.lua
@@ -1,10 +1,9 @@
 local api = require("nvim-paredit.api")
-local unwrap = require("nvim-paredit.api.unwrap")
 
 local M = {}
 
 M.default_keys = {
-  ["<localleader>@"] = { unwrap.unwrap_form_under_cursor, "Splice sexp" },
+  ["<localleader>@"] = { api.unwrap_form_under_cursor, "Splice sexp" },
 
   [">)"] = { api.slurp_forwards, "Slurp forwards" },
   [">("] = { api.barf_backwards, "Barf backwards" },

--- a/lua/nvim-paredit/utils/common.lua
+++ b/lua/nvim-paredit/utils/common.lua
@@ -93,11 +93,4 @@ function M.is_whitespace_under_cursor(lang)
     or char_under_cursor[1] == ""
 end
 
-function M.deprecate(fn, message)
-  return function(...)
-    print("Warning: Deprecated function called. " .. message)
-    return fn(...)
-  end
-end
-
 return M


### PR DESCRIPTION
This current documentation was getting a bit out of date and out of hand. Not everything was documented, some things were documented incorrectly and everything was in a single file.

This updates the documentation to be up-to-date with the current state of our API's and splits certain aspects into new files under `./docs`