### PR TITLE
Add scheme support

### DIFF
--- a/lua/nvim-paredit/defaults.lua
+++ b/lua/nvim-paredit/defaults.lua
@@ -119,7 +119,7 @@ M.defaults = {
     enabled = false,
     indentor = require("nvim-paredit.indentation.native").indentor,
   },
-  filetypes = { "clojure", "fennel" },
+  filetypes = { "clojure", "fennel", "scheme" },
   languages = {
     clojure = {
       whitespace_chars = { " ", "," },

--- a/queries/scheme/paredit/forms.scm
+++ b/queries/scheme/paredit/forms.scm
@@ -1,0 +1,6 @@
+(list) @form
+(vector) @form
+(byte_vector) @form
+
+(comment) @comment
+(block_comment) @comment

--- a/tests/config.lua
+++ b/tests/config.lua
@@ -11,6 +11,6 @@ vim.bo.swapfile = false
 
 require("nvim-treesitter.configs").setup({
   parser_install_dir = vim.fn.getcwd() .. "/.build/parsers",
-  ensure_installed = { "clojure", "fennel" },
+  ensure_installed = { "clojure", "fennel", "scheme" },
   sync_install = true,
 })

--- a/tests/nvim-paredit/scheme/element_raise_spec.lua
+++ b/tests/nvim-paredit/scheme/element_raise_spec.lua
@@ -1,0 +1,58 @@
+local paredit = require("nvim-paredit.api")
+
+local prepare_buffer = require("tests.nvim-paredit.utils").prepare_buffer
+local expect = require("tests.nvim-paredit.utils").expect
+
+describe("element raising", function()
+  vim.api.nvim_set_option_value("filetype", "scheme", {
+    buf = 0,
+  })
+
+  it("should raise the element", function()
+    prepare_buffer({
+      content = "(a (b))",
+      cursor = { 1, 4 },
+    })
+    paredit.raise_element()
+    expect({
+      content = "(a b)",
+      cursor = { 1, 3 },
+    })
+  end)
+
+  it("should raise form elements when cursor is placed on edge", function()
+    prepare_buffer({
+      content = "(a (b))",
+      cursor = { 1, 3 },
+    })
+
+    paredit.raise_element()
+    expect({
+      content = "(b)",
+      cursor = { 1, 0 },
+    })
+
+    prepare_buffer({
+      content = "(a #(b))",
+      cursor = { 1, 3 },
+    })
+
+    paredit.raise_element()
+    expect({
+      content = "#(b)",
+      cursor = { 1, 0 },
+    })
+  end)
+
+  it("should do nothing if it is a direct child of the document root", function()
+    prepare_buffer({
+      content = { "a", "b" },
+      cursor = { 1, 0 },
+    })
+    paredit.raise_form()
+    expect({
+      content = { "a", "b" },
+      cursor = { 1, 0 },
+    })
+  end)
+end)

--- a/tests/nvim-paredit/scheme/form_raise_spec.lua
+++ b/tests/nvim-paredit/scheme/form_raise_spec.lua
@@ -1,0 +1,61 @@
+local paredit = require("nvim-paredit.api")
+
+local prepare_buffer = require("tests.nvim-paredit.utils").prepare_buffer
+local expect_all = require("tests.nvim-paredit.utils").expect_all
+local expect = require("tests.nvim-paredit.utils").expect
+
+describe("form raising", function()
+  vim.api.nvim_set_option_value("filetype", "scheme", {
+    buf = 0,
+  })
+
+  it("should raise the form", function()
+    expect_all(paredit.raise_form, {
+      {
+        "list",
+        before_content = "(a (b c))",
+        before_cursor = { 1, 6 },
+        after_content = "(b c)",
+        after_cursor = { 1, 0 },
+      },
+      {
+        "list with reader",
+        before_content = "(a #(b c))",
+        before_cursor = { 1, 5 },
+        after_content = "#(b c)",
+        after_cursor = { 1, 0 },
+      },
+      {
+        "list with byte vector",
+        before_content = "(a #vu8(1 2))",
+        before_cursor = { 1, 3 },
+        after_content = "#vu8(1 2)",
+        after_cursor = { 1, 0 },
+      },
+    })
+  end)
+
+  it("should do nothing if it is a direct child of the document root", function()
+    prepare_buffer({
+      content = { "(a)", "b" },
+      cursor = { 1, 1 },
+    })
+    paredit.raise_form()
+    expect({
+      content = { "(a)", "b" },
+      cursor = { 1, 1 },
+    })
+  end)
+
+  it("should do nothing if it is outside of a form", function()
+    prepare_buffer({
+      content = { "a", "b" },
+      cursor = { 1, 0 },
+    })
+    paredit.raise_form()
+    expect({
+      content = { "a", "b" },
+      cursor = { 1, 0 },
+    })
+  end)
+end)

--- a/tests/nvim-paredit/scheme/motion_spec.lua
+++ b/tests/nvim-paredit/scheme/motion_spec.lua
@@ -1,0 +1,49 @@
+local paredit = require("nvim-paredit.api")
+
+local prepare_buffer = require("tests.nvim-paredit.utils").prepare_buffer
+local expect = require("tests.nvim-paredit.utils").expect
+
+describe("motions", function()
+  vim.api.nvim_set_option_value("filetype", "scheme", {
+    buf = 0,
+  })
+
+  it("should jump to next element in form (tail)", function()
+    prepare_buffer({
+      content = "(aa (bb) #(cc))",
+      cursor = { 1, 2 },
+    })
+
+    paredit.move_to_next_element_tail()
+    expect({
+      cursor = { 1, 7 },
+    })
+
+    paredit.move_to_next_element_tail()
+    expect({
+      cursor = { 1, 13 },
+    })
+
+    paredit.move_to_next_element_tail()
+    expect({
+      cursor = { 1, 13 },
+    })
+  end)
+
+  it("should jump to next element in form (head)", function()
+    prepare_buffer({
+      content = "(aa (bb) #(cc))",
+      cursor = { 1, 2 },
+    })
+
+    paredit.move_to_next_element_head()
+    expect({
+      cursor = { 1, 4 },
+    })
+
+    paredit.move_to_next_element_head()
+    expect({
+      cursor = { 1, 9 },
+    })
+  end)
+end)

--- a/tests/nvim-paredit/scheme/slurp_spec.lua
+++ b/tests/nvim-paredit/scheme/slurp_spec.lua
@@ -1,0 +1,93 @@
+local paredit = require("nvim-paredit.api")
+
+local prepare_buffer = require("tests.nvim-paredit.utils").prepare_buffer
+local expect_all = require("tests.nvim-paredit.utils").expect_all
+local expect = require("tests.nvim-paredit.utils").expect
+
+describe("slurping backwards", function()
+  vim.api.nvim_set_option_value("filetype", "scheme", {
+    buf = 0,
+  })
+
+  it("should slurp different form types", function()
+    expect_all(paredit.slurp_backwards, {
+      {
+        "list",
+        before_content = "a ()",
+        before_cursor = { 1, 3 },
+        after_content = "(a )",
+        after_cursor = { 1, 3 },
+      },
+      {
+        "vector",
+        before_content = "a #()",
+        before_cursor = { 1, 2 },
+        after_content = "#(a )",
+        after_cursor = { 1, 2 },
+      },
+      {
+        "byte vector",
+        before_content = "a #vu8()",
+        before_cursor = { 1, 4 },
+        after_content = "#vu8(a )",
+        after_cursor = { 1, 4 },
+      },
+    })
+  end)
+
+  it("should skip comments", function()
+    prepare_buffer({
+      content = { "a", ";; comment", "()" },
+      cursor = { 3, 0 },
+    })
+    paredit.slurp_backwards()
+    expect({
+      content = { "(a", ";; comment", ")" },
+      cursor = { 3, 0 },
+    })
+  end)
+end)
+
+describe("slurping forward", function()
+  vim.api.nvim_set_option_value("filetype", "scheme", {
+    buf = 0,
+  })
+
+  it("should slurp forward different form types", function()
+    expect_all(paredit.slurp_forwards, {
+      {
+        "list",
+        before_content = "() a",
+        before_cursor = { 1, 1 },
+        after_content = "( a)",
+        after_cursor = { 1, 1 },
+      },
+      {
+        "vector",
+        before_content = "#() a",
+        before_cursor = { 1, 1 },
+        after_content = "#( a)",
+        after_cursor = { 1, 1 },
+      },
+      {
+        "byte vector",
+        before_content = "#vu8() a",
+        before_cursor = { 1, 2 },
+        after_content = "#vu8( a)",
+        after_cursor = { 1, 2 },
+      },
+    })
+  end)
+
+  it("should skip comments", function()
+    prepare_buffer({
+      content = { "()", ";; comment", "a" },
+      cursor = { 1, 1 },
+    })
+    paredit.slurp_forwards()
+    expect({
+      content = { "(", ";; comment", "a)" },
+      cursor = { 1, 0 },
+    })
+  end)
+end)


### PR DESCRIPTION
This adds scheme treesitter grammars to nvim-paredit which effectively gives us out-of-the box scheme support.

This effectively supersedes https://github.com/ekaitz-zarraga/nvim-paredit-scheme