### PR TITLE
Improve native indent impl under some edge cases

### DIFF
--- a/lua/nvim-paredit/indentation/native.lua
+++ b/lua/nvim-paredit/indentation/native.lua
@@ -96,7 +96,11 @@ local function indent_barf(event)
   local lhs_range = { lhs:range() }
   local node_range = { node:range() }
 
-  if not utils.node_is_first_on_line(node, opts) or lhs_range[1] == node_range[1] then
+  if lhs_range[3] == node_range[1] then
+    return
+  end
+
+  if not utils.node_is_first_on_line(node, opts) then
     return
   end
 
@@ -136,13 +140,25 @@ local function indent_slurp(event)
   if event.type == "slurp-forwards" then
     child = parent:named_child(parent:named_child_count() - 1)
   else
-    child = parent:named_child(1)
+    local first = parent:named_child(0)
+    if not first then
+      return
+    end
+    child = traversal.get_next_sibling_ignoring_comments(first, opts)
+  end
+
+  if not child then
+    return
   end
 
   local parent_range = { parent:range() }
   local child_range = { child:range() }
 
-  if not utils.node_is_first_on_line(child, opts) or parent_range[1] == child_range[1] then
+  if parent_range[1] == child_range[1] then
+    return
+  end
+
+  if not utils.node_is_first_on_line(child, opts) then
     return
   end
 

--- a/lua/nvim-paredit/indentation/utils.lua
+++ b/lua/nvim-paredit/indentation/utils.lua
@@ -3,9 +3,19 @@ local common = require("nvim-paredit.utils.common")
 
 local M = {}
 
+local function get_corrected_line_range(range)
+  -- if the node is at the zeroth position on the last line, it's not actually
+  -- part of the line.
+  if range[4] == 0 then
+    return range[1], range[3] - 1
+  end
+  return range[1], range[3]
+end
+
 function M.get_node_line_range(range)
+  local start, _end = get_corrected_line_range(range)
   local lines = {}
-  for i = range[1], range[3], 1 do
+  for i = start, _end, 1 do
     table.insert(lines, i)
   end
   return lines
@@ -57,8 +67,8 @@ function M.node_is_first_on_line(node, opts)
     return true
   end
 
-  local sibling_range = { sibling:range() }
-  return sibling_range[3] ~= node_range[1]
+  local _, sibling_end = get_corrected_line_range({ sibling:range() })
+  return sibling_end ~= node_range[1]
 end
 
 -- This functions finds the closest sibling to a given `node` which is:

--- a/tests/nvim-paredit/barf_spec.lua
+++ b/tests/nvim-paredit/barf_spec.lua
@@ -60,7 +60,7 @@ describe("barfing ::", function()
           before_cursor = { 1, 3 },
           after_content = "#?(:cljs a :clj) b",
           after_cursor = { 1, 3 },
-        }
+        },
       })
     end)
 
@@ -147,15 +147,15 @@ describe("barfing ::", function()
           before_content = "(aa bb)",
           before_cursor = { 1, 5 },
           after_content = "(aa) bb",
-          after_cursor = { 1, 3 }
+          after_cursor = { 1, 3 },
         },
         {
           "multi line",
           before_content = { "(aa", "bb)" },
           before_cursor = { 2, 1 },
           after_content = { "(aa)", "bb" },
-          after_cursor = { 1, 3 }
-        }
+          after_cursor = { 1, 3 },
+        },
       })
     end)
 
@@ -170,15 +170,15 @@ describe("barfing ::", function()
           before_content = "(aa bb cc)",
           before_cursor = { 1, 4 },
           after_content = "(aa bb) cc",
-          after_cursor = { 1, 6 }
+          after_cursor = { 1, 6 },
         },
         {
           "multi line",
           before_content = { "(aa", "bb", "cc)" },
           before_cursor = { 1, 1 },
           after_content = { "(aa", "bb)", "cc" },
-          after_cursor = { 2, 2 }
-        }
+          after_cursor = { 2, 2 },
+        },
       })
     end)
   end)
@@ -248,7 +248,7 @@ describe("barfing ::", function()
       })
       paredit.barf_backwards()
       expect({
-        content = {"a ;; comment", "()"},
+        content = { "a ;; comment", "()" },
         cursor = { 2, 0 },
       })
     end)
@@ -314,15 +314,15 @@ describe("barfing ::", function()
           before_content = "(aa bb)",
           before_cursor = { 1, 1 },
           after_content = "aa (bb)",
-          after_cursor = { 1, 4 }
+          after_cursor = { 1, 4 },
         },
         {
           "multi line",
           before_content = { "(aa", "bb)" },
           before_cursor = { 1, 1 },
           after_content = { "aa", "(bb)" },
-          after_cursor = { 2, 0 }
-        }
+          after_cursor = { 2, 0 },
+        },
       })
     end)
 
@@ -337,15 +337,15 @@ describe("barfing ::", function()
           before_content = "(aa bb cc)",
           before_cursor = { 1, 1 },
           after_content = "aa (bb cc)",
-          after_cursor = { 1, 4 }
+          after_cursor = { 1, 4 },
         },
         {
           "multi line",
           before_content = { "(aa", "bb", "cc)" },
           before_cursor = { 1, 1 },
           after_content = { "aa", "(bb", "cc)" },
-          after_cursor = { 2, 0 }
-        }
+          after_cursor = { 2, 0 },
+        },
       })
     end)
   end)

--- a/tests/nvim-paredit/deletions_spec.lua
+++ b/tests/nvim-paredit/deletions_spec.lua
@@ -4,7 +4,7 @@ local prepare_buffer = require("tests.nvim-paredit.utils").prepare_buffer
 local expect_all = require("tests.nvim-paredit.utils").expect_all
 local expect = require("tests.nvim-paredit.utils").expect
 
-describe("form deletions", function()
+describe("form deletions ::", function()
   vim.api.nvim_set_option_value("filetype", "clojure", {
     buf = 0,
   })
@@ -93,7 +93,7 @@ describe("form deletions", function()
   end)
 end)
 
-describe("form inner deletions", function()
+describe("form inner deletions ::", function()
   vim.api.nvim_set_option_value("filetype", "clojure", {
     buf = 0,
   })
@@ -182,7 +182,7 @@ describe("form inner deletions", function()
   end)
 end)
 
-describe("element deletions", function()
+describe("element deletions ::", function()
   vim.api.nvim_set_option_value("filetype", "clojure", {
     buf = 0,
   })

--- a/tests/nvim-paredit/element_drag_spec.lua
+++ b/tests/nvim-paredit/element_drag_spec.lua
@@ -4,10 +4,11 @@ local prepare_buffer = require("tests.nvim-paredit.utils").prepare_buffer
 local expect_all = require("tests.nvim-paredit.utils").expect_all
 local expect = require("tests.nvim-paredit.utils").expect
 
-describe("element-dragging", function()
+describe("element dragging ::", function()
   vim.api.nvim_set_option_value("filetype", "clojure", {
     buf = 0,
   })
+
   local parser = vim.treesitter.get_parser(0)
   if not parser then
     return error("Failed to get parser for language")

--- a/tests/nvim-paredit/element_raise_spec.lua
+++ b/tests/nvim-paredit/element_raise_spec.lua
@@ -3,7 +3,7 @@ local paredit = require("nvim-paredit.api")
 local prepare_buffer = require("tests.nvim-paredit.utils").prepare_buffer
 local expect = require("tests.nvim-paredit.utils").expect
 
-describe("element raising", function()
+describe("element raising ::", function()
   vim.api.nvim_set_option_value("filetype", "clojure", {
     buf = 0,
   })

--- a/tests/nvim-paredit/form_and_element_wrap_spec.lua
+++ b/tests/nvim-paredit/form_and_element_wrap_spec.lua
@@ -2,7 +2,7 @@ local paredit = require("nvim-paredit")
 local prepare_buffer = require("tests.nvim-paredit.utils").prepare_buffer
 local expect = require("tests.nvim-paredit.utils").expect
 
-describe("element and form wrap", function()
+describe("form and element wrap ::", function()
   vim.api.nvim_set_option_value("filetype", "clojure", {
     buf = 0,
   })

--- a/tests/nvim-paredit/form_drag_spec.lua
+++ b/tests/nvim-paredit/form_drag_spec.lua
@@ -4,7 +4,7 @@ local prepare_buffer = require("tests.nvim-paredit.utils").prepare_buffer
 local expect_all = require("tests.nvim-paredit.utils").expect_all
 local expect = require("tests.nvim-paredit.utils").expect
 
-describe("form-dragging", function()
+describe("form dragging ::", function()
   vim.api.nvim_set_option_value("filetype", "clojure", {
     buf = 0,
   })

--- a/tests/nvim-paredit/form_raise_spec.lua
+++ b/tests/nvim-paredit/form_raise_spec.lua
@@ -4,7 +4,7 @@ local prepare_buffer = require("tests.nvim-paredit.utils").prepare_buffer
 local expect_all = require("tests.nvim-paredit.utils").expect_all
 local expect = require("tests.nvim-paredit.utils").expect
 
-describe("form raising", function()
+describe("form raising ::", function()
   vim.api.nvim_set_option_value("filetype", "clojure", {
     buf = 0,
   })

--- a/tests/nvim-paredit/form_unwrap_spec.lua
+++ b/tests/nvim-paredit/form_unwrap_spec.lua
@@ -2,10 +2,11 @@ local paredit = require("nvim-paredit")
 local prepare_buffer = require("tests.nvim-paredit.utils").prepare_buffer
 local expect = require("tests.nvim-paredit.utils").expect
 
-describe("form uwrap (e.g. splice)", function()
+describe("form uwrap ::", function()
   vim.api.nvim_set_option_value("filetype", "clojure", {
     buf = 0,
   })
+
   local unwrap = paredit.unwrap
 
   it("should uwrap list under cursor", function()

--- a/tests/nvim-paredit/indentation_spec.lua
+++ b/tests/nvim-paredit/indentation_spec.lua
@@ -9,208 +9,208 @@ local opts = vim.tbl_deep_extend("force", defaults.defaults, {
   },
 })
 
-describe("forward slurping indentation", function()
+describe("indentation ::", function()
   vim.api.nvim_set_option_value("filetype", "clojure", {
     buf = 0,
   })
-  local function slurp_forwards()
-    paredit.slurp_forwards(opts)
-  end
 
-  expect_all(slurp_forwards, {
-    {
-      "should indent a nested child",
-      before_content = { "()", "a" },
-      before_cursor = { 1, 1 },
-      after_content = { "(", " a)" },
-      after_cursor = { 1, 0 },
-    },
-    {
-      "should indent a nested child from a wrapped parent",
-      before_content = { "@()", "a" },
-      before_cursor = { 1, 2 },
-      after_content = { "@(", "  a)" },
-      after_cursor = { 1, 1 },
-    },
-    {
-      "should indent a multi-line child",
-      before_content = { "()", "(a", " b c)" },
-      before_cursor = { 1, 1 },
-      after_content = { "(", " (a", "  b c))" },
-      after_cursor = { 1, 0 },
-    },
-    {
-      "should indent a multi-line child that pushes other nodes",
-      before_content = { "()", "(a", " b) (c", "d) (e", "f)" },
-      before_cursor = { 1, 1 },
-      after_content = { "(", " (a", "  b)) (c", " d) (e", " f)" },
-      after_cursor = { 1, 0 },
-    },
-    {
-      "should not indent if node is not first on line",
-      before_content = { "(", "a) (a", "b)" },
-      before_cursor = { 1, 1 },
-      after_content = { "(", "a (a", "b))" },
-      after_cursor = { 1, 0 },
-    },
-    {
-      "should not indent when on same line",
-      before_content = "() 1",
-      before_cursor = { 1, 1 },
-      after_content = "( 1)",
-      after_cursor = { 1, 1 },
-    },
-    {
-      "should dedent when node is too far indented",
-      before_content = { "()", "  a" },
-      before_cursor = { 1, 1 },
-      after_content = { "(", " a)" },
-      after_cursor = { 1, 0 },
-    },
-    {
-      "should dedent without deleting characters",
-      before_content = { "()", "   (a", " b)" },
-      before_cursor = { 1, 1 },
-      after_content = { "(", "  (a", "b))" },
-      after_cursor = { 1, 0 },
-    },
-    {
-      "should indent the correct node ignoring comments",
-      before_content = { "()", ";; comment", "a" },
-      before_cursor = { 1, 1 },
-      after_content = { "(", ";; comment", " a)" },
-      after_cursor = { 1, 0 },
-    },
+  describe("forward slurping indentation", function()
+    local function slurp_forwards()
+      paredit.slurp_forwards(opts)
+    end
 
-    {
-      "should indent to the first relevant siblings indentation",
-      before_content = { "(def a []", "  target sibling)", "child" },
-      before_cursor = { 1, 1 },
-      after_content = { "(def a []", "  target sibling", "  child)" },
-      after_cursor = { 1, 1 },
-    },
-  })
-end)
+    expect_all(slurp_forwards, {
+      {
+        "should indent a nested child",
+        before_content = { "()", "a" },
+        before_cursor = { 1, 1 },
+        after_content = { "(", " a)" },
+        after_cursor = { 1, 0 },
+      },
+      {
+        "should indent a nested child from a wrapped parent",
+        before_content = { "@()", "a" },
+        before_cursor = { 1, 2 },
+        after_content = { "@(", "  a)" },
+        after_cursor = { 1, 1 },
+      },
+      {
+        "should indent a multi-line child",
+        before_content = { "()", "(a", " b c)" },
+        before_cursor = { 1, 1 },
+        after_content = { "(", " (a", "  b c))" },
+        after_cursor = { 1, 0 },
+      },
+      {
+        "should indent a multi-line child that pushes other nodes",
+        before_content = { "()", "(a", " b) (c", "d) (e", "f)" },
+        before_cursor = { 1, 1 },
+        after_content = { "(", " (a", "  b)) (c", " d) (e", " f)" },
+        after_cursor = { 1, 0 },
+      },
+      {
+        "should not indent if node is not first on line",
+        before_content = { "(", "a) (a", "b)" },
+        before_cursor = { 1, 1 },
+        after_content = { "(", "a (a", "b))" },
+        after_cursor = { 1, 0 },
+      },
+      {
+        "should not indent when on same line",
+        before_content = "() 1",
+        before_cursor = { 1, 1 },
+        after_content = "( 1)",
+        after_cursor = { 1, 1 },
+      },
+      {
+        "should dedent when node is too far indented",
+        before_content = { "()", "  a" },
+        before_cursor = { 1, 1 },
+        after_content = { "(", " a)" },
+        after_cursor = { 1, 0 },
+      },
+      {
+        "should dedent without deleting characters",
+        before_content = { "()", "   (a", " b)" },
+        before_cursor = { 1, 1 },
+        after_content = { "(", "  (a", "b))" },
+        after_cursor = { 1, 0 },
+      },
+      {
+        "should indent the correct node ignoring comments",
+        before_content = { "()", ";; comment", "a" },
+        before_cursor = { 1, 1 },
+        after_content = { "(", ";; comment", " a)" },
+        after_cursor = { 1, 0 },
+      },
 
-describe("backward slurping indentation", function()
-  vim.api.nvim_buf_set_option(0, "filetype", "clojure")
-  local function slurp_backwards()
-    paredit.slurp_backwards(opts)
-  end
+      {
+        "should indent to the first relevant siblings indentation",
+        before_content = { "(def a []", "  target sibling)", "child" },
+        before_cursor = { 1, 1 },
+        after_content = { "(def a []", "  target sibling", "  child)" },
+        after_cursor = { 1, 1 },
+      },
+    })
+  end)
 
-  expect_all(slurp_backwards, {
-    {
-      "should indent a nested child",
-      before_content = { "a", "(b)" },
-      before_cursor = { 2, 1 },
-      after_content = { "(a", " b)" },
-      after_cursor = { 2, 2 },
-    },
-    {
-      "should not indent when on same line",
-      before_content = { "a (b)" },
-      before_cursor = { 1, 3 },
-      after_content = { "(a b)" },
-      after_cursor = { 1, 3 },
-    },
-  })
-end)
+  describe("backward slurping indentation", function()
+    local function slurp_backwards()
+      paredit.slurp_backwards(opts)
+    end
 
-describe("forward barfing indentation", function()
-  vim.api.nvim_buf_set_option(0, "filetype", "clojure")
-  local function barf_forwards()
-    paredit.barf_forwards(opts)
-  end
+    expect_all(slurp_backwards, {
+      {
+        "should indent a nested child",
+        before_content = { "a", "(b)" },
+        before_cursor = { 2, 1 },
+        after_content = { "(a", " b)" },
+        after_cursor = { 2, 2 },
+      },
+      {
+        "should not indent when on same line",
+        before_content = { "a (b)" },
+        before_cursor = { 1, 3 },
+        after_content = { "(a b)" },
+        after_cursor = { 1, 3 },
+      },
+    })
+  end)
 
-  expect_all(barf_forwards, {
-    {
-      "should dedent the barfed child",
-      before_content = { "(", " a)" },
-      before_cursor = { 1, 0 },
-      after_content = { "()", "a" },
-      after_cursor = { 1, 0 },
-    },
-    {
-      "should dedent the barfed child from a wrapped parent",
-      before_content = { "@(", "  a)" },
-      before_cursor = { 1, 1 },
-      after_content = { "@()", "a" },
-      after_cursor = { 1, 1 },
-    },
-    {
-      "should dedent a multi-line child and affected siblings",
-      before_content = { "(", " (a", "  b c)) (a", " d)" },
-      before_cursor = { 1, 0 },
-      after_content = { "()", "(a", " b c) (a", "d)" },
-      after_cursor = { 1, 0 },
-    },
-    {
-      "should not dedent if node is on the same line",
-      before_content = { "(a", "b c)" },
-      before_cursor = { 1, 1 },
-      after_content = { "(a", "b) c" },
-      after_cursor = { 1, 1 },
-    },
-    {
-      "should not dedent when there is no indentation",
-      before_content = { "(", "a)" },
-      before_cursor = { 1, 0 },
-      after_content = { "()", "a" },
-      after_cursor = { 1, 0 },
-    },
-    {
-      "should dedent the minimum amount without deleting chars",
-      before_content = { "(", "  a) (b", " c)" },
-      before_cursor = { 1, 0 },
-      after_content = { "()", " a (b", "c)" },
-      after_cursor = { 1, 0 },
-    },
-    {
-      "should dedent the correct node ignoring comments",
-      before_content = { "(", ";; comment", " a)" },
-      before_cursor = { 1, 1 },
-      after_content = { "()", ";; comment", "a" },
-      after_cursor = { 1, 0 },
-    },
+  describe("forward barfing indentation", function()
+    local function barf_forwards()
+      paredit.barf_forwards(opts)
+    end
 
-    {
-      "should indent to the first relevant siblings indentation",
-      before_content = { "(def a []", "  target (sibling", "          child))" },
-      before_cursor = { 2, 10 },
-      after_content = { "(def a []", "  target (sibling)", "  child)" },
-      after_cursor = { 2, 10 },
-    },
-  })
-end)
+    expect_all(barf_forwards, {
+      {
+        "should dedent the barfed child",
+        before_content = { "(", " a)" },
+        before_cursor = { 1, 0 },
+        after_content = { "()", "a" },
+        after_cursor = { 1, 0 },
+      },
+      {
+        "should dedent the barfed child from a wrapped parent",
+        before_content = { "@(", "  a)" },
+        before_cursor = { 1, 1 },
+        after_content = { "@()", "a" },
+        after_cursor = { 1, 1 },
+      },
+      {
+        "should dedent a multi-line child and affected siblings",
+        before_content = { "(", " (a", "  b c)) (a", " d)" },
+        before_cursor = { 1, 0 },
+        after_content = { "()", "(a", " b c) (a", "d)" },
+        after_cursor = { 1, 0 },
+      },
+      {
+        "should not dedent if node is on the same line",
+        before_content = { "(a", "b c)" },
+        before_cursor = { 1, 1 },
+        after_content = { "(a", "b) c" },
+        after_cursor = { 1, 1 },
+      },
+      {
+        "should not dedent when there is no indentation",
+        before_content = { "(", "a)" },
+        before_cursor = { 1, 0 },
+        after_content = { "()", "a" },
+        after_cursor = { 1, 0 },
+      },
+      {
+        "should dedent the minimum amount without deleting chars",
+        before_content = { "(", "  a) (b", " c)" },
+        before_cursor = { 1, 0 },
+        after_content = { "()", " a (b", "c)" },
+        after_cursor = { 1, 0 },
+      },
+      {
+        "should dedent the correct node ignoring comments",
+        before_content = { "(", ";; comment", " a)" },
+        before_cursor = { 1, 1 },
+        after_content = { "()", ";; comment", "a" },
+        after_cursor = { 1, 0 },
+      },
 
-describe("backward barfing indentation", function()
-  vim.api.nvim_buf_set_option(0, "filetype", "clojure")
-  local function barf_backwards()
-    paredit.barf_backwards(opts)
-  end
+      {
+        "should indent to the first relevant siblings indentation",
+        before_content = { "(def a []", "  target (sibling", "          child))" },
+        before_cursor = { 2, 10 },
+        after_content = { "(def a []", "  target (sibling)", "  child)" },
+        after_cursor = { 2, 10 },
+      },
+    })
+  end)
 
-  expect_all(barf_backwards, {
-    {
-      "should dedent a nested child",
-      before_content = { "(a", " b)" },
-      before_cursor = { 1, 0 },
-      after_content = { "a", "(b)" },
-      after_cursor = { 2, 0 },
-    },
-    {
-      "should keep the cursor in the same place",
-      before_content = { "((a", "  bc", "  de))" },
-      before_cursor = { 2, 3 },
-      after_content = { "(a", " (bc", " de))" },
-      after_cursor = { 2, 3 },
-    },
+  describe("backward barfing indentation", function()
+    local function barf_backwards()
+      paredit.barf_backwards(opts)
+    end
 
-    {
-      "should indent to the first relevant siblings indentation",
-      before_content = { "(def a []", "  target (sibling", "          child))" },
-      before_cursor = { 3, 1 },
-      after_content = { "(def a []", "  target sibling", "  (child))" },
-      after_cursor = { 3, 2 },
-    },
-  })
+    expect_all(barf_backwards, {
+      {
+        "should dedent a nested child",
+        before_content = { "(a", " b)" },
+        before_cursor = { 1, 0 },
+        after_content = { "a", "(b)" },
+        after_cursor = { 2, 0 },
+      },
+      {
+        "should keep the cursor in the same place",
+        before_content = { "((a", "  bc", "  de))" },
+        before_cursor = { 2, 3 },
+        after_content = { "(a", " (bc", " de))" },
+        after_cursor = { 2, 3 },
+      },
+
+      {
+        "should indent to the first relevant siblings indentation",
+        before_content = { "(def a []", "  target (sibling", "          child))" },
+        before_cursor = { 3, 1 },
+        after_content = { "(def a []", "  target sibling", "  (child))" },
+        after_cursor = { 3, 2 },
+      },
+    })
+  end)
 end)

--- a/tests/nvim-paredit/indentation_spec.lua
+++ b/tests/nvim-paredit/indentation_spec.lua
@@ -63,6 +63,13 @@ describe("indentation ::", function()
         after_cursor = { 1, 1 },
       },
       {
+        "should not indent when on same line [multiline]",
+        before_content = {"(", " a) b"},
+        before_cursor = { 1, 0 },
+        after_content = {"(", " a b)"},
+        after_cursor = { 1, 0 },
+      },
+      {
         "should dedent when node is too far indented",
         before_content = { "()", "  a" },
         before_cursor = { 1, 1 },
@@ -78,9 +85,9 @@ describe("indentation ::", function()
       },
       {
         "should indent the correct node ignoring comments",
-        before_content = { "()", ";; comment", "a" },
+        before_content = { "()", ";; comment", "a ;; another comment", "b" },
         before_cursor = { 1, 1 },
-        after_content = { "(", ";; comment", " a)" },
+        after_content = { "(", ";; comment", " a) ;; another comment", "b" },
         after_cursor = { 1, 0 },
       },
 
@@ -108,11 +115,25 @@ describe("indentation ::", function()
         after_cursor = { 2, 2 },
       },
       {
+        "should indent with a comment in the way",
+        before_content = { "a ;; comment", "(b)" },
+        before_cursor = { 2, 1 },
+        after_content = { "(a ;; comment", " b)" },
+        after_cursor = { 2, 2 },
+      },
+      {
         "should not indent when on same line",
         before_content = { "a (b)" },
         before_cursor = { 1, 3 },
         after_content = { "(a b)" },
         after_cursor = { 1, 3 },
+      },
+      {
+        "should handle empty children",
+        before_content = { "a", "()" },
+        before_cursor = { 2, 1 },
+        after_content = { "(a", ")" },
+        after_cursor = { 2, 0 },
       },
     })
   end)
@@ -146,9 +167,9 @@ describe("indentation ::", function()
       },
       {
         "should not dedent if node is on the same line",
-        before_content = { "(a", "b c)" },
+        before_content = { "(a", " b c)" },
         before_cursor = { 1, 1 },
-        after_content = { "(a", "b) c" },
+        after_content = { "(a", " b) c" },
         after_cursor = { 1, 1 },
       },
       {

--- a/tests/nvim-paredit/motion_spec.lua
+++ b/tests/nvim-paredit/motion_spec.lua
@@ -5,7 +5,7 @@ local prepare_buffer = require("tests.nvim-paredit.utils").prepare_buffer
 local expect_all = require("tests.nvim-paredit.utils").expect_all
 local expect = require("tests.nvim-paredit.utils").expect
 
-describe("motions", function()
+describe("motions :: ", function()
   vim.api.nvim_set_option_value("filetype", "clojure", {
     buf = 0,
   })

--- a/tests/nvim-paredit/operator_motion_spec.lua
+++ b/tests/nvim-paredit/operator_motion_spec.lua
@@ -5,187 +5,177 @@ local keybindings = require("nvim-paredit.utils.keybindings")
 
 local defaults = require("nvim-paredit.defaults")
 
-describe("motions with operator pending", function()
-  before_each(function()
-    vim.api.nvim_set_option_value("filetype", "clojure", {
-      buf = 0,
-    })
+describe("operator pending :: ", function()
+  vim.api.nvim_set_option_value("filetype", "clojure", {
+    buf = 0,
+  })
 
-    keybindings.setup_keybindings({
-      keys = defaults.default_keys,
-    })
+  keybindings.setup_keybindings({
+    keys = defaults.default_keys,
+  })
+
+  describe("motions with operator pending", function()
+    it("should delete next form", function()
+      prepare_buffer({
+        content = "(a a) (b b)",
+        cursor = { 1, 0 },
+      })
+      feedkeys("d<S-e>")
+      expect({
+        content = " (b b)",
+        cursor = { 1, 0 },
+      })
+      vim.treesitter.get_parser(0):parse()
+      feedkeys("d<S-e>")
+      expect({
+        content = "",
+        cursor = { 1, 0 },
+      })
+    end)
+
+    it("should delete until the next element head", function()
+      prepare_buffer({
+        content = { "(a a)", "(b b)" },
+        cursor = { 1, 0 },
+      })
+      feedkeys("d<S-w>")
+      expect({
+        content = { "(b b)" },
+        cursor = { 1, 0 },
+      })
+    end)
+
+    it("should delete until the previous element tail", function()
+      prepare_buffer({
+        content = { "(a a)", "(b b)" },
+        cursor = { 2, 5 },
+      })
+      feedkeys("dg<S-e>")
+      expect({
+        content = { "(a a)" },
+        cursor = { 1, 4 },
+      })
+    end)
+
+    it("should delete til next", function()
+      prepare_buffer({
+        content = "(a a) (b b)",
+        cursor = { 1, 0 },
+      })
+      feedkeys("d<S-w>")
+      expect({
+        content = "(b b)",
+        cursor = { 1, 0 },
+      })
+    end)
+
+    it("should delete form if there is no next", function()
+      prepare_buffer({
+        content = "(b b)",
+        cursor = { 1, 0 },
+      })
+      feedkeys("d<S-w>")
+      expect({
+        content = "",
+        cursor = { 1, 0 },
+      })
+    end)
+
+    it("should delete 2 forms within parent form and join up", function()
+      prepare_buffer({
+        content = { "[(a a) (b b) (c c)]" },
+        cursor = { 1, 1 },
+      })
+      feedkeys("2d<S-w>")
+      expect({
+        content = "[(c c)]",
+        cursor = { 1, 1 },
+      })
+    end)
+
+    it("should delete next form (multiline)", function()
+      prepare_buffer({
+        content = { "(a a)", ";; comment", "(b b)" },
+        cursor = { 1, 0 },
+      })
+      feedkeys("d<S-e>")
+      expect({
+        content = { "", ";; comment", "(b b)" },
+        cursor = { 1, 0 },
+      })
+      vim.treesitter.get_parser(0):parse()
+      feedkeys("d<S-e>")
+      expect({
+        content = "",
+        cursor = { 1, 0 },
+      })
+    end)
+
+    it("should change next form", function()
+      prepare_buffer({
+        content = "(a a) (b b)",
+        cursor = { 1, 0 },
+      })
+      feedkeys("c<S-e>[a b]")
+      expect({
+        content = "[a b] (b b)",
+        cursor = { 1, 4 },
+      })
+    end)
+
+    it("should delete prev form", function()
+      prepare_buffer({
+        content = "(a a) (b b)",
+        cursor = { 1, 10 },
+      })
+      feedkeys("d<S-b>")
+      expect({
+        content = "(a a) ",
+        cursor = { 1, 5 },
+      })
+      feedkeys("d<S-b>")
+      expect({
+        content = "",
+        cursor = { 1, 0 },
+      })
+    end)
+
+    it("should change prev form", function()
+      prepare_buffer({
+        content = "(a a) (b b)",
+        cursor = { 1, 4 },
+      })
+      feedkeys("c<S-b>[a b]")
+      expect({
+        content = "[a b] (b b)",
+        cursor = { 1, 4 },
+      })
+    end)
   end)
 
-  it("should delete next form", function()
-    prepare_buffer({
-      content = "(a a) (b b)",
-      cursor = { 1, 0 },
-    })
-    feedkeys("d<S-e>")
-    expect({
-      content = " (b b)",
-      cursor = { 1, 0 },
-    })
-    vim.treesitter.get_parser(0):parse()
-    feedkeys("d<S-e>")
-    expect({
-      content = "",
-      cursor = { 1, 0 },
-    })
-  end)
+  describe("motions with operator pending and v:count", function()
+    it("should delete the next 2 elements", function()
+      prepare_buffer({
+        content = "(aa bb cc)",
+        cursor = { 1, 4 },
+      })
+      feedkeys("d2<S-e>")
+      expect({
+        content = "(aa )",
+        cursor = { 1, 4 },
+      })
+    end)
 
-  it("should delete until the next element head", function()
-    prepare_buffer({
-      content = { "(a a)", "(b b)" },
-      cursor = { 1, 0 },
-    })
-    feedkeys("d<S-w>")
-    expect({
-      content = { "(b b)" },
-      cursor = { 1, 0 },
-    })
-  end)
-
-  it("should delete until the previous element tail", function()
-    prepare_buffer({
-      content = { "(a a)", "(b b)" },
-      cursor = { 2, 5 },
-    })
-    feedkeys("dg<S-e>")
-    expect({
-      content = { "(a a)" },
-      cursor = { 1, 4 },
-    })
-  end)
-
-  it("should delete til next", function()
-    prepare_buffer({
-      content = "(a a) (b b)",
-      cursor = { 1, 0 },
-    })
-    feedkeys("d<S-w>")
-    expect({
-      content = "(b b)",
-      cursor = { 1, 0 },
-    })
-  end)
-
-  it("should delete form if there is no next", function()
-    prepare_buffer({
-      content = "(b b)",
-      cursor = { 1, 0 },
-    })
-    feedkeys("d<S-w>")
-    expect({
-      content = "",
-      cursor = { 1, 0 },
-    })
-  end)
-
-  it("should delete 2 forms within parent form and join up", function()
-    prepare_buffer({
-      content = { "[(a a) (b b) (c c)]" },
-      cursor = { 1, 1 },
-    })
-    feedkeys("2d<S-w>")
-    expect({
-      content = "[(c c)]",
-      cursor = { 1, 1 },
-    })
-  end)
-
-  it("should delete next form (multiline)", function()
-    prepare_buffer({
-      content = { "(a a)", ";; comment", "(b b)" },
-      cursor = { 1, 0 },
-    })
-    feedkeys("d<S-e>")
-    expect({
-      content = { "", ";; comment", "(b b)" },
-      cursor = { 1, 0 },
-    })
-    vim.treesitter.get_parser(0):parse()
-    feedkeys("d<S-e>")
-    expect({
-      content = "",
-      cursor = { 1, 0 },
-    })
-  end)
-
-  it("should change next form", function()
-    prepare_buffer({
-      content = "(a a) (b b)",
-      cursor = { 1, 0 },
-    })
-    feedkeys("c<S-e>[a b]")
-    expect({
-      content = "[a b] (b b)",
-      cursor = { 1, 4 },
-    })
-  end)
-
-  it("should delete prev form", function()
-    prepare_buffer({
-      content = "(a a) (b b)",
-      cursor = { 1, 10 },
-    })
-    feedkeys("d<S-b>")
-    expect({
-      content = "(a a) ",
-      cursor = { 1, 5 },
-    })
-    feedkeys("d<S-b>")
-    expect({
-      content = "",
-      cursor = { 1, 0 },
-    })
-  end)
-
-  it("should change prev form", function()
-    prepare_buffer({
-      content = "(a a) (b b)",
-      cursor = { 1, 4 },
-    })
-    feedkeys("c<S-b>[a b]")
-    expect({
-      content = "[a b] (b b)",
-      cursor = { 1, 4 },
-    })
-  end)
-end)
-
-describe("motions with operator pending and v:count", function()
-  before_each(function()
-    vim.api.nvim_set_option_value("filetype", "clojure", {
-      buf = 0,
-    })
-
-    keybindings.setup_keybindings({
-      keys = defaults.default_keys,
-    })
-  end)
-
-  it("should delete the next 2 elements", function()
-    prepare_buffer({
-      content = "(aa bb cc)",
-      cursor = { 1, 4 },
-    })
-    feedkeys("d2<S-e>")
-    expect({
-      content = "(aa )",
-      cursor = { 1, 4 },
-    })
-  end)
-
-  it("should delete the previous 2 elements", function()
-    prepare_buffer({
-      content = "(aa bb cc)",
-      cursor = { 1, 8 },
-    })
-    feedkeys("d2<S-b>")
-    expect({
-      content = "(aa )",
-      cursor = { 1, 4 },
-    })
+    it("should delete the previous 2 elements", function()
+      prepare_buffer({
+        content = "(aa bb cc)",
+        cursor = { 1, 8 },
+      })
+      feedkeys("d2<S-b>")
+      expect({
+        content = "(aa )",
+        cursor = { 1, 4 },
+      })
+    end)
   end)
 end)

--- a/tests/nvim-paredit/pair_drag_spec.lua
+++ b/tests/nvim-paredit/pair_drag_spec.lua
@@ -4,87 +4,93 @@ local prepare_buffer = require("tests.nvim-paredit.utils").prepare_buffer
 local expect_all = require("tests.nvim-paredit.utils").expect_all
 local expect = require("tests.nvim-paredit.utils").expect
 
-describe("paired-element-auto-dragging", function()
+describe("pair dragging ::", function()
   vim.api.nvim_set_option_value("filetype", "clojure", {
     buf = 0,
   })
-  it("should drag map pairs forward", function()
-    prepare_buffer({
-      content = "{:a 1 :b 2}",
-      cursor = { 1, 1 },
-    })
 
-    paredit.drag_element_forwards({
-      dragging = {
-        auto_drag_pairs = true,
-      },
+  describe("paired-element-auto-dragging", function()
+    vim.api.nvim_set_option_value("filetype", "clojure", {
+      buf = 0,
     })
-    expect({
-      content = "{:b 2 :a 1}",
-      cursor = { 1, 6 },
-    })
+    it("should drag map pairs forward", function()
+      prepare_buffer({
+        content = "{:a 1 :b 2}",
+        cursor = { 1, 1 },
+      })
+
+      paredit.drag_element_forwards({
+        dragging = {
+          auto_drag_pairs = true,
+        },
+      })
+      expect({
+        content = "{:b 2 :a 1}",
+        cursor = { 1, 6 },
+      })
+    end)
+
+    it("should drag map pairs backwards", function()
+      prepare_buffer({
+        content = "{:a 1 :b 2}",
+        cursor = { 1, 9 },
+      })
+
+      paredit.drag_element_backwards({
+        dragging = {
+          auto_drag_pairs = true,
+        },
+      })
+      expect({
+        content = "{:b 2 :a 1}",
+        cursor = { 1, 1 },
+      })
+    end)
+
+    it("should detect various types", function()
+      expect_all(function()
+        paredit.drag_element_forwards({ dragging = { auto_drag_pairs = true } })
+      end, {
+        {
+          "let binding",
+          before_content = "(let [a b c d])",
+          before_cursor = { 1, 6 },
+          after_content = "(let [c d a b])",
+          after_cursor = { 1, 10 },
+        },
+        {
+          "loop binding",
+          before_content = "(loop [a b c d])",
+          before_cursor = { 1, 7 },
+          after_content = "(loop [c d a b])",
+          after_cursor = { 1, 11 },
+        },
+        {
+          "case",
+          before_content = "(case a :a 1 :b 2)",
+          before_cursor = { 1, 8 },
+          after_content = "(case a :b 2 :a 1)",
+          after_cursor = { 1, 13 },
+        },
+      })
+    end)
   end)
 
-  it("should drag map pairs backwards", function()
-    prepare_buffer({
-      content = "{:a 1 :b 2}",
-      cursor = { 1, 9 },
+  describe("paired-element-dragging", function()
+    vim.api.nvim_set_option_value("filetype", "clojure", {
+      buf = 0,
     })
+    it("should drag vector elements forwards", function()
+      prepare_buffer({
+        content = "'[a b c d]",
+        cursor = { 1, 2 },
+      })
 
-    paredit.drag_element_backwards({
-      dragging = {
-        auto_drag_pairs = true,
-      },
-    })
-    expect({
-      content = "{:b 2 :a 1}",
-      cursor = { 1, 1 },
-    })
-  end)
-
-  it("should detect various types", function()
-    expect_all(function()
-      paredit.drag_element_forwards({ dragging = { auto_drag_pairs = true } })
-    end, {
-      {
-        "let binding",
-        before_content = "(let [a b c d])",
-        before_cursor = { 1, 6 },
-        after_content = "(let [c d a b])",
-        after_cursor = { 1, 10 },
-      },
-      {
-        "loop binding",
-        before_content = "(loop [a b c d])",
-        before_cursor = { 1, 7 },
-        after_content = "(loop [c d a b])",
-        after_cursor = { 1, 11 },
-      },
-      {
-        "case",
-        before_content = "(case a :a 1 :b 2)",
-        before_cursor = { 1, 8 },
-        after_content = "(case a :b 2 :a 1)",
-        after_cursor = { 1, 13 },
-      },
-    })
-  end)
-end)
-
-describe("paired-element-dragging", function()
-  vim.api.nvim_set_option_value("filetype", "clojure", {
-    buf = 0,
-  })
-  it("should drag vector elements forwards", function()
-    prepare_buffer({
-      content = "'[a b c d]",
-      cursor = { 1, 2 },
-    })
-
-    paredit.drag_pair_forwards()
-    expect({
-      content = "'[c d a b]",
-      cursor = { 1, 6 },
-    })
+      paredit.drag_pair_forwards()
+      expect({
+        content = "'[c d a b]",
+        cursor = { 1, 6 },
+      })
+    end)
   end)
 end)

--- a/tests/nvim-paredit/slurp_spec.lua
+++ b/tests/nvim-paredit/slurp_spec.lua
@@ -4,245 +4,240 @@ local prepare_buffer = require("tests.nvim-paredit.utils").prepare_buffer
 local expect_all = require("tests.nvim-paredit.utils").expect_all
 local expect = require("tests.nvim-paredit.utils").expect
 
-describe("slurping backward", function()
+describe("slurping :: ", function()
   vim.api.nvim_set_option_value("filetype", "clojure", {
     buf = 0,
   })
+
   local parser = vim.treesitter.get_parser(0)
   if not parser then
     return error("Failed to get parser for language")
   end
 
-  it("should slurp different form types", function()
-    expect_all(paredit.slurp_backwards, {
-      {
-        "list",
-        before_content = "a ()",
-        before_cursor = { 1, 3 },
-        after_content = "(a )",
-        after_cursor = { 1, 3 },
-      },
-      {
-        "vector",
-        before_content = "a []",
-        before_cursor = { 1, 3 },
-        after_content = "[a ]",
-        after_cursor = { 1, 3 },
-      },
-      {
-        "quoted list",
-        before_content = "a `()",
-        before_cursor = { 1, 4 },
-        after_content = "`(a )",
-        after_cursor = { 1, 4 },
-      },
-      {
-        "quoted list",
-        before_content = "a '()",
-        before_cursor = { 1, 4 },
-        after_content = "'(a )",
-        after_cursor = { 1, 4 },
-      },
-      {
-        "anon fn",
-        before_content = "a #()",
-        before_cursor = { 1, 4 },
-        after_content = "#(a )",
-        after_cursor = { 1, 4 },
-      },
-      {
-        "set",
-        before_content = "a #{}",
-        before_cursor = { 1, 4 },
-        after_content = "#{a }",
-        after_cursor = { 1, 4 },
-      },
-      {
-        "reader conditional",
-        before_content = "a #?(:clj)",
-        before_cursor = { 1, 5 },
-        after_content = "#?(a :clj)",
-        after_cursor = { 1, 5 },
-      }
-    })
+  describe("slurping backward", function()
+    it("should slurp different form types", function()
+      expect_all(paredit.slurp_backwards, {
+        {
+          "list",
+          before_content = "a ()",
+          before_cursor = { 1, 3 },
+          after_content = "(a )",
+          after_cursor = { 1, 3 },
+        },
+        {
+          "vector",
+          before_content = "a []",
+          before_cursor = { 1, 3 },
+          after_content = "[a ]",
+          after_cursor = { 1, 3 },
+        },
+        {
+          "quoted list",
+          before_content = "a `()",
+          before_cursor = { 1, 4 },
+          after_content = "`(a )",
+          after_cursor = { 1, 4 },
+        },
+        {
+          "quoted list",
+          before_content = "a '()",
+          before_cursor = { 1, 4 },
+          after_content = "'(a )",
+          after_cursor = { 1, 4 },
+        },
+        {
+          "anon fn",
+          before_content = "a #()",
+          before_cursor = { 1, 4 },
+          after_content = "#(a )",
+          after_cursor = { 1, 4 },
+        },
+        {
+          "set",
+          before_content = "a #{}",
+          before_cursor = { 1, 4 },
+          after_content = "#{a }",
+          after_cursor = { 1, 4 },
+        },
+        {
+          "reader conditional",
+          before_content = "a #?(:clj)",
+          before_cursor = { 1, 5 },
+          after_content = "#?(a :clj)",
+          after_cursor = { 1, 5 },
+        },
+      })
+    end)
+
+    it("should skip comments", function()
+      prepare_buffer({
+        content = { "a", ";; comment", "()" },
+        cursor = { 3, 0 },
+      })
+      paredit.slurp_backwards()
+      expect({
+        content = { "(a", ";; comment", ")" },
+        cursor = { 3, 0 },
+      })
+    end)
+
+    it("should recursively slurp the next sibling", function()
+      prepare_buffer({
+        content = "1 2 (())",
+        cursor = { 1, 5 },
+      })
+
+      paredit.slurp_backwards()
+      expect({
+        content = "1 (2 ())",
+        cursor = { 1, 5 },
+      })
+
+      parser:parse()
+
+      paredit.slurp_backwards()
+      expect({
+        content = "1 ((2 ))",
+        cursor = { 1, 5 },
+      })
+
+      parser:parse()
+
+      paredit.slurp_backwards()
+      expect({
+        content = "(1 (2 ))",
+        cursor = { 1, 5 },
+      })
+
+      parser:parse()
+
+      paredit.slurp_backwards()
+      expect({
+        content = "((1 2 ))",
+        cursor = { 1, 5 },
+      })
+    end)
+
+    it("should follow the bracket with cursor", function()
+      prepare_buffer({
+        content = "1 2 ()",
+        cursor = { 1, 4 },
+      })
+      paredit.slurp_backwards({ cursor_behaviour = "follow" })
+      expect({
+        content = "1 (2 )",
+        cursor = { 1, 2 },
+      })
+    end)
   end)
 
-  it("should skip comments", function()
-    prepare_buffer({
-      content = { "a", ";; comment", "()" },
-      cursor = { 3, 0 },
-    })
-    paredit.slurp_backwards()
-    expect({
-      content = { "(a", ";; comment", ")" },
-      cursor = { 3, 0 },
-    })
-  end)
+  describe("slurping forward", function()
+    it("should slurp forward different form types", function()
+      expect_all(paredit.slurp_forwards, {
+        {
+          "list",
+          before_content = "() a",
+          before_cursor = { 1, 1 },
+          after_content = "( a)",
+          after_cursor = { 1, 1 },
+        },
+        {
+          "vector",
+          before_content = "[] a",
+          before_cursor = { 1, 1 },
+          after_content = "[ a]",
+          after_cursor = { 1, 1 },
+        },
+        {
+          "quoted list",
+          before_content = "`() a",
+          before_cursor = { 1, 2 },
+          after_content = "`( a)",
+          after_cursor = { 1, 2 },
+        },
+        {
+          "quoted list",
+          before_content = "'() a",
+          before_cursor = { 1, 2 },
+          after_content = "'( a)",
+          after_cursor = { 1, 2 },
+        },
+        {
+          "anon fn",
+          before_content = "#() a",
+          before_cursor = { 1, 2 },
+          after_content = "#( a)",
+          after_cursor = { 1, 2 },
+        },
+        {
+          "set",
+          before_content = "#{} a",
+          before_cursor = { 1, 2 },
+          after_content = "#{ a}",
+          after_cursor = { 1, 2 },
+        },
+      })
+    end)
 
-  it("should recursively slurp the next sibling", function()
-    prepare_buffer({
-      content = "1 2 (())",
-      cursor = { 1, 5 },
-    })
+    it("should skip comments", function()
+      prepare_buffer({
+        content = { "()", ";; comment", "a" },
+        cursor = { 1, 1 },
+      })
+      paredit.slurp_forwards()
+      expect({
+        content = { "(", ";; comment", "a)" },
+        cursor = { 1, 0 },
+      })
+    end)
 
-    paredit.slurp_backwards()
-    expect({
-      content = "1 (2 ())",
-      cursor = { 1, 5 },
-    })
+    it("should recursively slurp the next sibling", function()
+      prepare_buffer({
+        content = "(()) 1 2",
+        cursor = { 1, 2 },
+      })
 
-    parser:parse()
+      paredit.slurp_forwards()
+      expect({
+        content = "(() 1) 2",
+        cursor = { 1, 2 },
+      })
 
-    paredit.slurp_backwards()
-    expect({
-      content = "1 ((2 ))",
-      cursor = { 1, 5 },
-    })
+      parser:parse()
 
-    parser:parse()
+      paredit.slurp_forwards()
+      expect({
+        content = "(( 1)) 2",
+        cursor = { 1, 2 },
+      })
 
-    paredit.slurp_backwards()
-    expect({
-      content = "(1 (2 ))",
-      cursor = { 1, 5 },
-    })
+      parser:parse()
 
-    parser:parse()
+      paredit.slurp_forwards()
+      expect({
+        content = "(( 1) 2)",
+        cursor = { 1, 2 },
+      })
 
-    paredit.slurp_backwards()
-    expect({
-      content = "((1 2 ))",
-      cursor = { 1, 5 },
-    })
-  end)
+      parser:parse()
 
-  it("should follow the bracket with cursor", function()
-    prepare_buffer({
-      content = "1 2 ()",
-      cursor = { 1, 4 },
-    })
-    paredit.slurp_backwards({ cursor_behaviour = "follow" })
-    expect({
-      content = "1 (2 )",
-      cursor = { 1, 2 },
-    })
-  end)
-end)
+      paredit.slurp_forwards()
+      expect({
+        content = "(( 1 2))",
+        cursor = { 1, 2 },
+      })
+    end)
 
-describe("slurping forward", function()
-  vim.api.nvim_set_option_value("filetype", "clojure", {
-    buf = 0,
-  })
-  local parser = vim.treesitter.get_parser(0)
-  if not parser then
-    return error("Failed to get parser for language")
-  end
-
-  it("should slurp forward different form types", function()
-    expect_all(paredit.slurp_forwards, {
-      {
-        "list",
-        before_content = "() a",
-        before_cursor = { 1, 1 },
-        after_content = "( a)",
-        after_cursor = { 1, 1 },
-      },
-      {
-        "vector",
-        before_content = "[] a",
-        before_cursor = { 1, 1 },
-        after_content = "[ a]",
-        after_cursor = { 1, 1 },
-      },
-      {
-        "quoted list",
-        before_content = "`() a",
-        before_cursor = { 1, 2 },
-        after_content = "`( a)",
-        after_cursor = { 1, 2 },
-      },
-      {
-        "quoted list",
-        before_content = "'() a",
-        before_cursor = { 1, 2 },
-        after_content = "'( a)",
-        after_cursor = { 1, 2 },
-      },
-      {
-        "anon fn",
-        before_content = "#() a",
-        before_cursor = { 1, 2 },
-        after_content = "#( a)",
-        after_cursor = { 1, 2 },
-      },
-      {
-        "set",
-        before_content = "#{} a",
-        before_cursor = { 1, 2 },
-        after_content = "#{ a}",
-        after_cursor = { 1, 2 },
-      },
-    })
-  end)
-
-  it("should skip comments", function()
-    prepare_buffer({
-      content = { "()", ";; comment", "a" },
-      cursor = { 1, 1 },
-    })
-    paredit.slurp_forwards()
-    expect({
-      content = { "(", ";; comment", "a)" },
-      cursor = { 1, 0 },
-    })
-  end)
-
-  it("should recursively slurp the next sibling", function()
-    prepare_buffer({
-      content = "(()) 1 2",
-      cursor = { 1, 2 },
-    })
-
-    paredit.slurp_forwards()
-    expect({
-      content = "(() 1) 2",
-      cursor = { 1, 2 },
-    })
-
-    parser:parse()
-
-    paredit.slurp_forwards()
-    expect({
-      content = "(( 1)) 2",
-      cursor = { 1, 2 },
-    })
-
-    parser:parse()
-
-    paredit.slurp_forwards()
-    expect({
-      content = "(( 1) 2)",
-      cursor = { 1, 2 },
-    })
-
-    parser:parse()
-
-    paredit.slurp_forwards()
-    expect({
-      content = "(( 1 2))",
-      cursor = { 1, 2 },
-    })
-  end)
-
-  it("should follow the bracket with cursor", function()
-    prepare_buffer({
-      content = "() 1 2",
-      cursor = { 1, 1 },
-    })
-    paredit.slurp_forwards({ cursor_behaviour = "follow" })
-    expect({
-      content = "( 1) 2",
-      cursor = { 1, 3 },
-    })
+    it("should follow the bracket with cursor", function()
+      prepare_buffer({
+        content = "() 1 2",
+        cursor = { 1, 1 },
+      })
+      paredit.slurp_forwards({ cursor_behaviour = "follow" })
+      expect({
+        content = "( 1) 2",
+        cursor = { 1, 3 },
+      })
+    end)
   end)
 end)

--- a/tests/nvim-paredit/text_object_selections_spec.lua
+++ b/tests/nvim-paredit/text_object_selections_spec.lua
@@ -6,239 +6,189 @@ local feedkeys = require("tests.nvim-paredit.utils").feedkeys
 local expect = require("tests.nvim-paredit.utils").expect
 local utils = require("tests.nvim-paredit.utils")
 
-describe("form deletions", function()
+describe("text object selections :: ", function()
   vim.api.nvim_set_option_value("filetype", "clojure", {
     buf = 0,
   })
 
-  before_each(function()
-    keybindings.setup_keybindings({
-      keys = defaults.default_keys,
-    })
-  end)
-
-  it("should delete the form", function()
-    prepare_buffer({
-      content = "(a a)",
-      cursor = { 1, 1 },
-    })
-    feedkeys("daf")
-    expect({
-      content = "",
-      cursor = { 1, 0 },
-    })
-  end)
-
-  it("should delete a multi line form", function()
-    prepare_buffer({
-      content = { "(a", "b", "c)" },
-      cursor = { 1, 1 },
-    })
-    feedkeys("daf")
-    expect({
-      content = "",
-      cursor = { 1, 0 },
-    })
-  end)
-
-  it("should delete a nested form", function()
-    prepare_buffer({
-      content = "(a (b c))",
-      cursor = { 1, 5 },
-    })
-    feedkeys("daf")
-    expect({
-      content = "(a )",
-      cursor = { 1, 3 },
-    })
-  end)
-
-  it("should delete the reader conditional form", function()
-    prepare_buffer({
-      content = "#?(:clj a :cljs a)",
-      cursor = { 1, 5 },
-    })
-    feedkeys("daf")
-    expect({
-      content = "",
-      cursor = { 1, 0 },
-    })
-  end)
-
-  it("should delete everything in the form", function()
-    prepare_buffer({
-      content = "(a b)",
-      cursor = { 1, 2 },
-    })
-    feedkeys("dif")
-    expect({
-      content = "()",
-      cursor = { 1, 1 },
-    })
-  end)
-
-  it("should delete everything within a multi line form", function()
-    prepare_buffer({
-      content = { "(a", "b", "c)" },
-      cursor = { 2, 0 },
-    })
-    feedkeys("dif")
-    expect({
-      content = "()",
-      cursor = { 1, 1 },
-    })
-  end)
-
-  it("should delete everything in the reader conditional form", function()
-    prepare_buffer({
-      content = "#?(:clj a b)",
-      cursor = { 1, 4 },
-    })
-    feedkeys("dif")
-    expect({
-      content = "#?()",
-      cursor = { 1, 3 },
-    })
-  end)
-end)
-
-describe("top level form deletions", function()
-  vim.api.nvim_set_option_value("filetype", "clojure", {
-    buf = 0,
+  keybindings.setup_keybindings({
+    keys = defaults.default_keys,
   })
 
-  before_each(function()
-    keybindings.setup_keybindings({
-      keys = defaults.default_keys,
-    })
+  describe("form deletions", function()
+    it("should delete the form", function()
+      prepare_buffer({
+        content = "(a a)",
+        cursor = { 1, 1 },
+      })
+      feedkeys("daf")
+      expect({
+        content = "",
+        cursor = { 1, 0 },
+      })
+    end)
+
+    it("should delete a multi line form", function()
+      prepare_buffer({
+        content = { "(a", "b", "c)" },
+        cursor = { 1, 1 },
+      })
+      feedkeys("daf")
+      expect({
+        content = "",
+        cursor = { 1, 0 },
+      })
+    end)
+
+    it("should delete a nested form", function()
+      prepare_buffer({
+        content = "(a (b c))",
+        cursor = { 1, 5 },
+      })
+      feedkeys("daf")
+      expect({
+        content = "(a )",
+        cursor = { 1, 3 },
+      })
+    end)
+
+    it("should delete the reader conditional form", function()
+      prepare_buffer({
+        content = "#?(:clj a :cljs a)",
+        cursor = { 1, 5 },
+      })
+      feedkeys("daf")
+      expect({
+        content = "",
+        cursor = { 1, 0 },
+      })
+    end)
+
+    it("should delete everything in the form", function()
+      prepare_buffer({
+        content = "(a b)",
+        cursor = { 1, 2 },
+      })
+      feedkeys("dif")
+      expect({
+        content = "()",
+        cursor = { 1, 1 },
+      })
+    end)
+
+    it("should delete everything within a multi line form", function()
+      prepare_buffer({
+        content = { "(a", "b", "c)" },
+        cursor = { 2, 0 },
+      })
+      feedkeys("dif")
+      expect({
+        content = "()",
+        cursor = { 1, 1 },
+      })
+    end)
+
+    it("should delete everything in the reader conditional form", function()
+      prepare_buffer({
+        content = "#?(:clj a b)",
+        cursor = { 1, 4 },
+      })
+      feedkeys("dif")
+      expect({
+        content = "#?()",
+        cursor = { 1, 3 },
+      })
+    end)
   end)
 
-  it("should delete the top level form, leaving other forms intact", function()
-    prepare_buffer({
-      content = { "(+ 1 2)", "(foo (a", "b", "c)) (comment thing)", "(x y)" },
-      cursor = { 2, 7 },
-    })
-    feedkeys("daF")
-    expect({
-      content = { "(+ 1 2)", " (comment thing)", "(x y)" },
-      cursor = { 2, 0 },
-    })
+  describe("top level form deletions", function()
+    it("should delete the top level form, leaving other forms intact", function()
+      prepare_buffer({
+        content = { "(+ 1 2)", "(foo (a", "b", "c)) (comment thing)", "(x y)" },
+        cursor = { 2, 7 },
+      })
+      feedkeys("daF")
+      expect({
+        content = { "(+ 1 2)", " (comment thing)", "(x y)" },
+        cursor = { 2, 0 },
+      })
+    end)
+
+    it("should delete inside the top level form, leaving other forms and the outer parenthesis pair intact", function()
+      prepare_buffer({
+        content = { "(+ 1 2)", "(foo (a", "b", "c)) (comment thing)", "(x y)" },
+        cursor = { 2, 7 },
+      })
+      feedkeys("diF")
+      expect({
+        content = { "(+ 1 2)", "() (comment thing)", "(x y)" },
+        cursor = { 2, 1 },
+      })
+    end)
   end)
 
-  it("should delete inside the top level form, leaving other forms and the outer parenthesis pair intact", function()
-    prepare_buffer({
-      content = { "(+ 1 2)", "(foo (a", "b", "c)) (comment thing)", "(x y)" },
-      cursor = { 2, 7 },
-    })
-    feedkeys("diF")
-    expect({
-      content = { "(+ 1 2)", "() (comment thing)", "(x y)" },
-      cursor = { 2, 1 },
-    })
-  end)
-end)
+  describe("form selections", function()
+    it("should select the form", function()
+      prepare_buffer({
+        content = "(a a)",
+        cursor = { 1, 1 },
+      })
+      feedkeys("vaf")
+      assert.are.same("(a a)", utils.get_selected_text())
+    end)
 
-describe("form selections", function()
-  vim.api.nvim_set_option_value("filetype", "clojure", {
-    buf = 0,
-  })
-
-  before_each(function()
-    keybindings.setup_keybindings({
-      keys = defaults.default_keys,
-    })
+    it("should select within the form", function()
+      prepare_buffer({
+        content = "(a a)",
+        cursor = { 1, 1 },
+      })
+      feedkeys("vif")
+      assert.are.same("a a", utils.get_selected_text())
+    end)
   end)
 
-  it("should select the form", function()
-    prepare_buffer({
-      content = "(a a)",
-      cursor = { 1, 1 },
-    })
-    feedkeys("vaf")
-    assert.are.same("(a a)", utils.get_selected_text())
+  describe("top form selections", function()
+    it("should select the root form and not the siblings", function()
+      prepare_buffer({
+        content = { "(+ 1 2)", "(foo (a", "a)) (/ 6 2)" },
+        cursor = { 2, 6 },
+      })
+      feedkeys("vaF")
+      assert.are.same("(foo (a\na))", utils.get_selected_text())
+    end)
+
+    it("should select within the form", function()
+      prepare_buffer({
+        content = { "(+ 1 2)", "(foo (a", "a)) (/ 6 2)" },
+        cursor = { 2, 6 },
+      })
+      feedkeys("viF")
+      assert.are.same("foo (a\na)", utils.get_selected_text())
+    end)
   end)
 
-  it("should select within the form", function()
-    prepare_buffer({
-      content = "(a a)",
-      cursor = { 1, 1 },
-    })
-    feedkeys("vif")
-    assert.are.same("a a", utils.get_selected_text())
-  end)
-end)
-
-describe("top form selections", function()
-  vim.api.nvim_set_option_value("filetype", "clojure", {
-    buf = 0,
-  })
-
-  before_each(function()
-    keybindings.setup_keybindings({
-      keys = defaults.default_keys,
-    })
+  describe("element deletions", function()
+    it("should delete the element", function()
+      prepare_buffer({
+        content = "(a :a/b)",
+        cursor = { 1, 5 },
+      })
+      feedkeys("die")
+      expect({
+        content = "(a )",
+        cursor = { 1, 3 },
+      })
+    end)
   end)
 
-  it("should select the root form and not the siblings", function()
-    prepare_buffer({
-      content = { "(+ 1 2)", "(foo (a", "a)) (/ 6 2)" },
-      cursor = { 2, 6 },
-    })
-    feedkeys("vaF")
-    assert.are.same("(foo (a\na))", utils.get_selected_text())
-  end)
-
-  it("should select within the form", function()
-    prepare_buffer({
-      content = { "(+ 1 2)", "(foo (a", "a)) (/ 6 2)" },
-      cursor = { 2, 6 },
-    })
-    feedkeys("viF")
-    assert.are.same("foo (a\na)", utils.get_selected_text())
-  end)
-end)
-
-describe("element deletions", function()
-  vim.api.nvim_set_option_value("filetype", "clojure", {
-    buf = 0,
-  })
-
-  before_each(function()
-    keybindings.setup_keybindings({
-      keys = defaults.default_keys,
-    })
-  end)
-
-  it("should delete the element", function()
-    prepare_buffer({
-      content = "(a :a/b)",
-      cursor = { 1, 5 },
-    })
-    feedkeys("die")
-    expect({
-      content = "(a )",
-      cursor = { 1, 3 },
-    })
-  end)
-end)
-
-describe("element selections", function()
-  vim.api.nvim_set_option_value("filetype", "clojure", {
-    buf = 0,
-  })
-
-  before_each(function()
-    keybindings.setup_keybindings({
-      keys = defaults.default_keys,
-    })
-  end)
-
-  it("should select the element", function()
-    prepare_buffer({
-      content = "(a :a/b)",
-      cursor = { 1, 5 },
-    })
-    feedkeys("vie")
-    assert.are.same(":a/b", utils.get_selected_text())
+  describe("element selections", function()
+    it("should select the element", function()
+      prepare_buffer({
+        content = "(a :a/b)",
+        cursor = { 1, 5 },
+      })
+      feedkeys("vie")
+      assert.are.same(":a/b", utils.get_selected_text())
+    end)
   end)
 end)


### PR DESCRIPTION
There are a few cases, especially when comments are involved, where the indent would break or do the wrong thing.

This adds some more tests for edge-cases and fixes the behaviour for those cases.