### PR TITLE
Swap both elements of a pair together

### DIFF
--- a/lua/nvim-paredit/api/text.lua
+++ b/lua/nvim-paredit/api/text.lua
@@ -1,0 +1,40 @@
+local M = {}
+
+-- Swap the text in the given buffer represented by left_range and right_range
+function M.swap_ranges(buf, left_range, right_range, cursor_pos)
+  -- stylua: ignore
+  local left_text = vim.api.nvim_buf_get_text(
+    buf,
+    left_range[1], left_range[2],
+    left_range[3], left_range[4],
+    {}
+  )
+  -- stylua: ignore
+  local right_text = vim.api.nvim_buf_get_text(buf,
+    right_range[1], right_range[2],
+    right_range[3], right_range[4],
+    {}
+  )
+
+  -- stylua: ignore
+  vim.api.nvim_buf_set_text(buf,
+    right_range[1], right_range[2],
+    right_range[3], right_range[4],
+    left_text
+  )
+  if cursor_pos == 1 then
+    vim.api.nvim_win_set_cursor(0, { right_range[1] + 1, right_range[2] })
+  end
+
+  -- stylua: ignore
+  vim.api.nvim_buf_set_text(buf,
+    left_range[1], left_range[2],
+    left_range[3], left_range[4],
+    right_text
+  )
+  if cursor_pos == 0 then
+    vim.api.nvim_win_set_cursor(0, { left_range[1] + 1, left_range[2] })
+  end
+end
+
+return M

--- a/lua/nvim-paredit/treesitter/pairs.lua
+++ b/lua/nvim-paredit/treesitter/pairs.lua
@@ -10,7 +10,7 @@ local M = {}
 -- matched nodes.
 function M.find_pairwise_nodes(target_node, opts)
   local root_node = ts_utils.find_local_root(target_node)
-  local enclosing_form = ts_forms.find_nearest_form(target_node, opts)
+  local enclosing_form = ts_forms.get_node_root(target_node, opts):parent()
   if not enclosing_form then
     return
   end

--- a/tests/nvim-paredit/motion_spec.lua
+++ b/tests/nvim-paredit/motion_spec.lua
@@ -268,52 +268,43 @@ describe("motions :: ", function()
   it("should move to parent form start", function()
     -- (aa (bb) @(|cc) #{1})
     prepare_buffer({
-      content = "(aa (bb) @(cc) #{1})",
-      cursor = { 1, 11 },
+      "(aa (bb) @(|cc) #{1})"
     })
 
-    -- (aa (bb) @|(cc) #{1})
     internal_api.move_to_parent_form_start()
     expect({
-      cursor = { 1, 10 },
+      "(aa (bb) @|(cc) #{1})"
     })
 
-    -- |(aa (bb) @(cc) #{1})
     internal_api.move_to_parent_form_start()
     expect({
-      cursor = { 1, 0 },
+      "|(aa (bb) @(cc) #{1})"
     })
 
-    -- |(aa (bb) @(cc) #{1})
     internal_api.move_to_parent_form_start()
     expect({
-      cursor = { 1, 0 },
+      "|(aa (bb) @(cc) #{1})"
     })
   end)
 
   it("should move to parent form end", function()
-    -- (aa (bb) |@(cc) #{1})
     prepare_buffer({
-      content = "(aa (bb) @(cc) #{1})",
-      cursor = { 1, 9 },
+      "(aa (bb) |@(cc) #{1})",
     })
 
-    -- (aa (bb) @(cc|) #{1})
     internal_api.move_to_parent_form_end()
     expect({
-      cursor = { 1, 13 },
+      "(aa (bb) @(cc|) #{1})",
     })
 
-    -- (aa (bb) @(cc) #{1}|)
     internal_api.move_to_parent_form_end()
     expect({
-      cursor = { 1, 19 },
+      "(aa (bb) @(cc) #{1}|)",
     })
 
-    -- (aa (bb) @(cc) #{1}|)
     internal_api.move_to_parent_form_end()
     expect({
-      cursor = { 1, 19 },
+      "(aa (bb) @(cc) #{1}|)",
     })
   end)
 end)

--- a/tests/nvim-paredit/pair_drag_spec.lua
+++ b/tests/nvim-paredit/pair_drag_spec.lua
@@ -30,6 +30,44 @@ describe("pair dragging ::", function()
       })
     end)
 
+    it("should drag multiline pairs", function()
+      prepare_buffer({
+        "{:a |{:a1 1",
+        "     :a2 2}",
+        " :b {:b1 1",
+        "     :b2 2}}",
+      })
+      paredit.drag_element_forwards({
+        dragging = {
+          auto_drag_pairs = true,
+        },
+      })
+      expect({
+        "{:b {:b1 1",
+        "     :b2 2}",
+        " |:a {:a1 1",
+        "     :a2 2}}",
+      })
+    end)
+
+    it("should drag pairs with differing line counts", function()
+      prepare_buffer({
+        "{:a |{:a1 1",
+        "     :a2 2}",
+        " :b {:b1 1 :b2 2}}",
+      })
+      paredit.drag_element_forwards({
+        dragging = {
+          auto_drag_pairs = true,
+        },
+      })
+      expect({
+        "{:b {:b1 1 :b2 2}",
+        " |:a {:a1 1",
+        "     :a2 2}}",
+      })
+    end)
+
     it("should drag map pairs backwards", function()
       prepare_buffer({
         content = "{:a 1 :b 2}",


### PR DESCRIPTION
Currently when performing a swap, each element in a pair is swapped with it's corresponding paired element.

This works for simple cases but breaks when the number of lines are different between the two pairs as the ranges the nodes represent have now changed from previous edits.

This fixes the issue by finding the full range represented by both elements in a pair and swapping this entire range in one go.