### PR TITLE
Add handling space for around operation.

### DIFF
--- a/lua/nvim-paredit/api/init.lua
+++ b/lua/nvim-paredit/api/init.lua
@@ -40,6 +40,7 @@ local M = {
   select_around_top_level_form = selections.select_around_top_level_form,
   select_in_top_level_form = selections.select_in_top_level_form,
   select_element = selections.select_element,
+  select_around_element = selections.select_around_element,
 
   delete_form = deletions.delete_form,
   delete_in_form = deletions.delete_in_form,

--- a/lua/nvim-paredit/api/selections.lua
+++ b/lua/nvim-paredit/api/selections.lua
@@ -10,6 +10,27 @@ function M.ensure_visual_mode()
   end
 end
 
+local function adjust_range_for_whitespace(range)
+  local start_row, start_col, end_row, end_col = unpack(range)
+
+  local end_line = vim.api.nvim_buf_get_lines(0, end_row, end_row + 1, false)[1]
+  if end_col < #end_line then
+    local after = end_line:sub(end_col + 1, end_col + 2)
+    if after:match(" [^;]") then
+      return { start_row, start_col, end_row, end_col + 1 }
+    end
+  end
+
+  local start_line = vim.api.nvim_buf_get_lines(0, start_row, start_row + 1, false)[1]
+  if start_col > 2 then
+    local before = start_line:sub(start_col - 1, start_col)
+    if before:match("[^;] ") then
+      return { start_row, start_col - 1, end_row, end_col }
+    end
+  end
+  return { start_row, start_col, end_row, end_col }
+end
+
 local function get_range_around_form_impl(node_fn)
   local context = ts_context.create_context()
   if not context then
@@ -34,10 +55,7 @@ local function get_range_around_form_impl(node_fn)
   local range = { root:range() }
 
   -- stylua: ignore
-  return {
-    range[1], range[2],
-    range[3], range[4],
-  }
+  return adjust_range_for_whitespace({ range[1], range[2], range[3], range[4] })
 end
 
 function M.get_range_around_form()
@@ -141,6 +159,20 @@ function M.select_element()
   end
 
   local range = M.get_element_range(context)
+
+  M.ensure_visual_mode()
+  vim.api.nvim_win_set_cursor(0, { range[1] + 1, range[2] })
+  vim.api.nvim_command("normal! o")
+  vim.api.nvim_win_set_cursor(0, { range[3] + 1, range[4] - 1 })
+end
+
+function M.select_around_element()
+  local context = ts_context.create_context()
+  if not context then
+    return
+  end
+
+  local range = adjust_range_for_whitespace(M.get_element_range(context))
 
   M.ensure_visual_mode()
   vim.api.nvim_win_set_cursor(0, { range[1] + 1, range[2] })

--- a/lua/nvim-paredit/defaults.lua
+++ b/lua/nvim-paredit/defaults.lua
@@ -92,7 +92,7 @@ M.default_keys = {
   },
 
   ["ae"] = {
-    api.select_element,
+    api.select_around_element,
     "Around element",
     repeatable = false,
     mode = { "o", "v" },

--- a/tests/nvim-paredit/deletions_spec.lua
+++ b/tests/nvim-paredit/deletions_spec.lua
@@ -40,8 +40,8 @@ describe("form deletions ::", function()
     })
     paredit.delete_form()
     expect({
-      content = "(a )",
-      cursor = { 1, 3 },
+      content = "(a)",
+      cursor = { 1, 2 },
     })
   end)
 

--- a/tests/nvim-paredit/text_object_selections_spec.lua
+++ b/tests/nvim-paredit/text_object_selections_spec.lua
@@ -47,8 +47,8 @@ describe("text object selections :: ", function()
       })
       feedkeys("daf")
       expect({
-        content = "(a )",
-        cursor = { 1, 3 },
+        content = "(a)",
+        cursor = { 1, 2 },
       })
     end)
 
@@ -109,7 +109,7 @@ describe("text object selections :: ", function()
       })
       feedkeys("daF")
       expect({
-        content = { "(+ 1 2)", " (comment thing)", "(x y)" },
+        content = { "(+ 1 2)", "(comment thing)", "(x y)" },
         cursor = { 2, 0 },
       })
     end)
@@ -154,7 +154,7 @@ describe("text object selections :: ", function()
         cursor = { 2, 6 },
       })
       feedkeys("vaF")
-      assert.are.same("(foo (a\na))", utils.get_selected_text())
+      assert.are.same("(foo (a\na)) ", utils.get_selected_text())
     end)
 
     it("should select within the form", function()


### PR DESCRIPTION
Firstly, thank you for creating this plugin. I use it daily and it’s been really helpful.
I would like to humbly suggest changing the around operation to include surrounding spaces as well.

To me, it feels natural to be able to remove forms/elements continuously with daf or dae, just like how daw removes a word along with its space. Currently, I often find myself needing to type dafx instead.

That said, I understand if this behavior was implemented intentionally. Since it could be a breaking change, I completely understand if you decide not to accept this PR. Thanks again!
