### PR TITLE
Update test workflow to use nvim-treesitter's main branch

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,14 +13,15 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        channel: 
-        - v0.10.4
+        channel:
         - v0.11.1
         - nightly
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v6
 
-    - uses: extractions/setup-just@v1
+    - uses: tree-sitter/setup-action@v2
+
+    - uses: extractions/setup-just@v3
 
     - name: Run tests [${{ matrix.channel }}]
       run: just test ${{ matrix.channel }}

--- a/Justfile
+++ b/Justfile
@@ -48,6 +48,9 @@ test channel="stable" file="": (prepare channel)
   #!/usr/bin/env bash
   set -eo pipefail
 
+  # Needed for curl to download tree-sitter parsers
+  mkdir -p "$HOME/.cache/nvim"
+
   NVIM_DIR=".build/nvim/{{ channel }}"
 
   ./$NVIM_DIR/bin/nvim --version

--- a/tests/config.lua
+++ b/tests/config.lua
@@ -1,16 +1,16 @@
 vim.opt.runtimepath:append("./.build/dependencies/plenary.nvim")
 vim.opt.runtimepath:append("./.build/dependencies/nvim-treesitter")
-vim.opt.runtimepath:append("./.build/parsers")
 vim.opt.runtimepath:append(".")
 
 vim.cmd.runtime({ "plugin/plenary.vim", bang = true })
 vim.cmd.runtime({ "plugin/nvim-treesitter.lua", bang = true })
+vim.cmd.runtime({ "plugin/query_predicates.lua", bang = true })
+vim.cmd.runtime({ "plugin/filetypes.lua", bang = true })
 
 vim.o.swapfile = false
 vim.bo.swapfile = false
 
-require("nvim-treesitter.configs").setup({
-  parser_install_dir = vim.fn.getcwd() .. "/.build/parsers",
-  ensure_installed = { "clojure", "fennel", "scheme", "commonlisp", "janet_simple" },
-  sync_install = true,
-})
+require("nvim-treesitter").setup({ install_dir = vim.fn.getcwd() .. "/.build/parsers" })
+
+
+require("nvim-treesitter.install").install({ "clojure", "fennel", "scheme", "commonlisp", "janet_simple" }):wait()


### PR DESCRIPTION
We should wait until nvim-treesitter officially switches the default branch to `main` before merging this PR.