### PR TITLE
Fix extraneous error on moving to parent form when already at the root

### DIFF
--- a/lua/nvim-paredit/api/motions.lua
+++ b/lua/nvim-paredit/api/motions.lua
@@ -200,7 +200,8 @@ end
 
 local function move_to_parent_form_edge(direction)
   local context = ts_context.create_context()
-  if not context then
+  -- if we dont get a node, or are already at the root, we no-op.
+  if not context or not context.node or ts_utils.is_document_root(context.node) then
     return
   end
 

--- a/tests/nvim-paredit/motion_spec.lua
+++ b/tests/nvim-paredit/motion_spec.lua
@@ -287,6 +287,12 @@ describe("motions :: ", function()
     })
   end)
 
+  it("should noop when moving to parent form, from between top forms", function()
+    prepare_buffer({ "(+ 1 2) | (+ 3 4)" })
+    internal_api.move_to_parent_form_start()
+    expect({ "(+ 1 2) | (+ 3 4)" })
+  end)
+
   it("should move to parent form end", function()
     prepare_buffer({
       "(aa (bb) |@(cc) #{1})",


### PR DESCRIPTION
Fixes #103.

The error itself happens because `get_form_edges` throws when given the root node, instead of returning the edges of it. This in-turn seems to be because `:range()` on the root node returns the line after the last line with content in the buffer, along with a column value of 0. This causes the `right_range` [here](https://github.com/julienvincent/nvim-paredit/blob/86ef02ec249b41471545f07f1baa21615a9ba8fa/lua/nvim-paredit/treesitter/forms.lua#L171) to contain -1 as the index, which blows up when we give this to `vim.api.nvim_buf_get_text`.

I opted to sidestep the question of what `get_form_edges` should return when given the root node, by fixing the problem directly in `move_to_parent_form_edge`. That said, it may be worth fixing `get_form_edges` to do the right thing when given the root node. But, the root node is definitely almost never a single form, so it also makes sense to me, to say that it must not be called with a node that is not a form. WDYT?