### PR TITLE
Adding raise_form and raise_element support for fennel if_form

### DIFF
--- a/lua/nvim-paredit/api/raising.lua
+++ b/lua/nvim-paredit/api/raising.lua
@@ -16,7 +16,7 @@ function M.raise_form()
     return
   end
 
-  local parent = current_form:parent()
+  local parent = ts_forms.find_enclosing_form(current_form, context.captures)
   if not parent or ts_utils.is_document_root(parent) then
     return
   end
@@ -42,7 +42,7 @@ function M.raise_element()
 
   local current_node = ts_forms.get_node_root(context.node, context)
 
-  local parent = current_node:parent()
+  local parent = ts_forms.find_enclosing_form(current_node, context.captures)
   if not parent or ts_utils.is_document_root(parent) then
     return
   end

--- a/lua/nvim-paredit/treesitter/forms.lua
+++ b/lua/nvim-paredit/treesitter/forms.lua
@@ -59,31 +59,21 @@ function M.find_nearest_form(current_node, opts)
   end
 end
 
-local function find_next_parent_form(current_node, captures)
-  local is_form = M.node_is_form(current_node, {
+-- Climb up the node's parents and return the first enclosing form.
+function M.find_enclosing_form(node, captures)
+  local parent = node:parent()
+  if not parent then
+    return nil
+  end
+  return M.find_nearest_form(parent, {
     captures = captures,
     recursive = false,
   })
-  if is_form then
-    return current_node
-  end
-
-  local parent = current_node:parent()
-  if not parent then
-    return current_node
-  end
-
-  return find_next_parent_form(parent, captures)
 end
 
 function M.get_node_root(node, opts)
-  local search_point = node
-  if M.node_is_form(node, opts) then
-    search_point = node:parent()
-  end
-
-  local root = find_next_parent_form(search_point, opts.captures)
-  return ts_utils.find_root_element_relative_to(root, node)
+  local root = M.find_enclosing_form(node, opts.captures) or node
+  return ts_utils.find_root_element_relative_to(root, node, opts.captures)
 end
 
 -- If a wrapped form node is provided this will return the inner most form node

--- a/lua/nvim-paredit/treesitter/utils.lua
+++ b/lua/nvim-paredit/treesitter/utils.lua
@@ -20,6 +20,15 @@ function M.find_local_root(node)
   return current
 end
 
+-- Whether `node` is an element of `root` and therefore the node we should stop
+-- on. This is true when `node` is a direct child of `root`, or when it has been
+-- explicitly captured as a `form.element` (e.g. a clause nested below a Fennel
+-- `if_pair`).
+local function is_element_of(root, node, captures)
+  local parent = node:parent()
+  return not parent or root:equal(parent) or common.included_in_table(captures[node:id()] or {}, "form.element")
+end
+
 -- Find the root most parent of the given `child` node which is still contained within
 -- the given `root` node.
 --
@@ -31,15 +40,11 @@ end
 -- The enclosing `(` `)` brackets would be given as `root` while the inner list would be
 -- given as `child`. The inner list may be wrapped in a `quoting` node, which is the
 -- actual node we are wanting to operate on.
-function M.find_root_element_relative_to(root, child)
-  local parent = child:parent()
-  if not parent then
+function M.find_root_element_relative_to(root, child, captures)
+  if is_element_of(root, child, captures) then
     return child
   end
-  if root:equal(parent) then
-    return child
-  end
-  return M.find_root_element_relative_to(root, parent)
+  return M.find_root_element_relative_to(root, child:parent(), captures)
 end
 
 function M.node_is_comment(node, opts)

--- a/queries/fennel/paredit/forms.scm
+++ b/queries/fennel/paredit/forms.scm
@@ -12,7 +12,10 @@
 (match_form) @form
 (case_try_form) @form
 (match_try_form) @form
-(if_form) @form
+(if_form
+  (if_pair
+    condition: (_) @form.element
+    expression: (_) @form.element)) @form
 (fn_form) @form
 (lambda_form) @form
 (macro_form) @form

--- a/tests/nvim-paredit/fennel/element_raise_spec.lua
+++ b/tests/nvim-paredit/fennel/element_raise_spec.lua
@@ -57,12 +57,116 @@ describe("element raising", function()
     })
   end)
 
+  it("should raise the condition of an if pair", function()
+    prepare_buffer({
+      content = "(if a (b))",
+      cursor = { 1, 4 },
+    })
+
+    paredit.raise_element()
+    expect({
+      content = "a",
+      cursor = { 1, 0 },
+    })
+  end)
+
+  it("should raise the expression of an if pair when on its edge", function()
+    prepare_buffer({
+      content = "(if a (b))",
+      cursor = { 1, 6 },
+    })
+
+    paredit.raise_element()
+    expect({
+      content = "(b)",
+      cursor = { 1, 0 },
+    })
+  end)
+
+  it("should raise an inner symbol of an if pair expression", function()
+    prepare_buffer({
+      content = "(if a (b))",
+      cursor = { 1, 7 },
+    })
+
+    paredit.raise_element()
+    expect({
+      content = "(if a b)",
+      cursor = { 1, 6 },
+    })
+  end)
+
+  it("should raise a nested form from an if pair expression", function()
+    prepare_buffer({
+      content = "(if a (b (+ 1 1)))",
+      cursor = { 1, 9 },
+    })
+
+    paredit.raise_element()
+    expect({
+      content = "(if a (+ 1 1))",
+      cursor = { 1, 6 },
+    })
+  end)
+
+  it("should raise the expression of a later if pair", function()
+    prepare_buffer({
+      content = "(if a (b) c (d))",
+      cursor = { 1, 12 },
+    })
+
+    paredit.raise_element()
+    expect({
+      content = "(d)",
+      cursor = { 1, 0 },
+    })
+  end)
+
+  it("should raise an inner symbol of a later if pair expression", function()
+    prepare_buffer({
+      content = "(if a (b) c (d))",
+      cursor = { 1, 13 },
+    })
+
+    paredit.raise_element()
+    expect({
+      content = "(if a (b) c d)",
+      cursor = { 1, 12 },
+    })
+  end)
+
+  it("should raise the else branch of an if", function()
+    prepare_buffer({
+      content = "(if a (b) (c))",
+      cursor = { 1, 10 },
+    })
+
+    paredit.raise_element()
+    expect({
+      content = "(c)",
+      cursor = { 1, 0 },
+    })
+  end)
+
+  it("should raise an element out of a multi-line if form", function()
+    prepare_buffer({
+      content = { "(if a (b)", "c (d e)", "f)" },
+      cursor = { 2, 3 },
+    })
+
+    paredit.raise_element()
+    expect({
+      content = { "(if a (b)", "c d", "f)" },
+      cursor = { 2, 2 },
+    })
+  end)
+
   it("should do nothing if it is a direct child of the document root", function()
     prepare_buffer({
       content = { "a", "b" },
       cursor = { 1, 0 },
     })
-    paredit.raise_form()
+    paredit.raise_element()
     expect({
       content = { "a", "b" },
       cursor = { 1, 0 },

--- a/tests/nvim-paredit/fennel/form_raise_spec.lua
+++ b/tests/nvim-paredit/fennel/form_raise_spec.lua
@@ -41,6 +41,84 @@ describe("form raising", function()
     })
   end)
 
+  it("should raise a form out of an if pair", function()
+    prepare_buffer({
+      content = "(if a (b c))",
+      cursor = { 1, 7 },
+    })
+
+    paredit.raise_form()
+    expect({
+      content = "(b c)",
+      cursor = { 1, 0 },
+    })
+  end)
+
+  it("should raise a nested form from an if pair expression", function()
+    prepare_buffer({
+      content = "(if a (b (+ 1 1)))",
+      cursor = { 1, 12 },
+    })
+
+    paredit.raise_form()
+    expect({
+      content = "(if a (+ 1 1))",
+      cursor = { 1, 6 },
+    })
+  end)
+
+  it("should raise a form out of a later if pair expression", function()
+    prepare_buffer({
+      content = "(if a (b) c (d e f))",
+      cursor = { 1, 13 },
+    })
+
+    paredit.raise_form()
+    expect({
+      content = "(d e f)",
+      cursor = { 1, 0 },
+    })
+  end)
+
+  it("should raise the condition of an if", function()
+    prepare_buffer({
+      content = "(if a (b) (c))",
+      cursor = { 1, 6 },
+    })
+
+    paredit.raise_form()
+    expect({
+      content = "(b)",
+      cursor = { 1, 0 },
+    })
+  end)
+
+  it("should raise the else branch of an if", function()
+    prepare_buffer({
+      content = "(if a (b) (c))",
+      cursor = { 1, 10 },
+    })
+
+    paredit.raise_form()
+    expect({
+      content = "(c)",
+      cursor = { 1, 0 },
+    })
+  end)
+
+  it("should raise a form out of a multi-line if form", function()
+    prepare_buffer({
+      content = { "(if a (b)", "c (d e)", "f)" },
+      cursor = { 2, 3 },
+    })
+
+    paredit.raise_form()
+    expect({
+      content = { "(d e)" },
+      cursor = { 1, 0 },
+    })
+  end)
+
   it("should do nothing if it is a direct child of the document root", function()
     prepare_buffer({
       content = { "(a)", "b" },


### PR DESCRIPTION
Fennel's tree-sitter grammar has the concept of 'pair' nodes which are neither a form nor an element (related to https://github.com/julienvincent/nvim-paredit/issues/83).
Because of this, there's an issue when raising forms or elements in Fennel.

Current:

```fennel
(if a |(b) c) → a (b)
```

Expected:

```fennel
(if a |(b) c) → (b)
```

This happens because:

1. The search stops at an `if_pair` node when searching for the current form or element under the cursor.
2. When searching for the parent node to replace with the current node, the `if_pair` was returned, instead of the `if_form`.

This PR introduces matches for the form elements of an `if_pair` node as suggested in https://github.com/julienvincent/nvim-paredit/issues/83 and resolves this issue for `raise_element` and `raise_form`.
It makes two new behavior changes: when walking upwards to get the current node's root, it will stop on a `@form.element` (in addition to its existing behavior of stopping on a direct child of the enclosing form). Also, when looking for the parent to operate on, it will keep walking up until it finds a node that is a `@form` (instead of returning the immediate parent, which may be `if_pair`).

Some new or refactored functions:

- Changes `find_next_parent_form` references to `find_enclosing_form` and removes `find_next_parent_form`. `find_next_parent_form` returned the current node if it was a form. `find_enclosing_form` will walk up from the node's parent using `find_nearest_form`. `find_nearest_form` currently largely does what `find_next_parent_form` did.
- Adds new `is_element_of` function to determine if a node is an element of the given root node.

Another approach to solving this might be to mark the `if_pair` as a `@transparent` capture or something similar, and skip it whenever traversing the tree.

Let me know if there are any pitfalls to this approach and if this aligns with your vision for the plugin!